### PR TITLE
added Quicksorter named chest logic

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # Quicksort mod
 mod_version = 0.14.1+1.21.4-prerelease
 maven_group = net.pcal
-archives_base_name = quicksort-Komino
+archives_base_name = quicksort
 
 # Fabric & Minecraft
 # https://fabricmc.net/develop

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # Quicksort mod
 mod_version = 0.14.1+1.21.4-prerelease
 maven_group = net.pcal
-archives_base_name = quicksort
+archives_base_name = quicksort-Komino
 
 # Fabric & Minecraft
 # https://fabricmc.net/develop

--- a/src/main/java/net/pcal/quicksort/QuicksortConfig.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortConfig.java
@@ -12,6 +12,7 @@ public record QuicksortConfig(
 ) {
 
     public record QuicksortChestConfig(
+            String chestName,
             ResourceLocation baseBlockId,
             int range,
             int cooldownTicks,

--- a/src/main/java/net/pcal/quicksort/QuicksortConfigParser.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortConfigParser.java
@@ -29,6 +29,7 @@ class QuicksortConfigParser {
         final QuicksortConfigGson configGson = gson.fromJson(rawJson, QuicksortConfigGson.class);
         for (QuicksortChestConfigGson chestGson : configGson.quicksortChests) {
             chests.add(defaultChestConfig = createWithDefaults(defaultChestConfig,
+                    chestGson.chestName,
                     chestGson.baseBlockId,
                     chestGson.range,
                     chestGson.cooldownTicks,
@@ -47,6 +48,7 @@ class QuicksortConfigParser {
 
     static QuicksortChestConfig createWithDefaults(
             QuicksortChestConfig dflt,
+            String chestName,
             String baseBlockId,
             Integer range,
             Integer cooldownTicks,
@@ -55,8 +57,19 @@ class QuicksortConfigParser {
             Float soundPitch,
             Collection<String> enchantmentMatchingIds,
             Collection<String> targetContainerIds) {
+
+        // First, check if chestName is provided, if so, use it.
+        String finalChestName = (chestName != null && !chestName.isEmpty()) ? chestName : (dflt == null ? null : dflt.chestName());
+
+        // If chestName is not provided, fallback to baseBlockId, and convert it to ResourceLocation
+        ResourceLocation finalBaseBlockId = (finalChestName == null && baseBlockId != null && !baseBlockId.isEmpty())
+                ? ResourceLocation.parse(baseBlockId)
+                : (dflt == null ? null : dflt.baseBlockId());
+
         return new QuicksortChestConfig(
-                ResourceLocation.parse(requireNonNull(baseBlockId, "baseBlockId is required")),
+                //ResourceLocation.parse(requireNonNull(baseBlockId, "baseBlockId is required")),
+                finalChestName,  // Use chestName if available
+                finalBaseBlockId != null ? ResourceLocation.parse(requireNonNull(baseBlockId, "baseBlockId is required")) : null,  // Only use baseBlockId if chestName is not present
                 requireNonNull(range != null ? range : dflt == null ? null : dflt.range(),
                         "range is required"),
                 requireNonNull(cooldownTicks != null ? cooldownTicks : dflt == null ? null : dflt.cooldownTicks(),
@@ -102,6 +115,7 @@ class QuicksortConfigParser {
     }
 
     public static class QuicksortChestConfigGson {
+        String chestName;
         String baseBlockId;
         Integer range;
         Integer cooldownTicks;

--- a/src/main/java/net/pcal/quicksort/QuicksortService.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortService.java
@@ -133,6 +133,17 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
     // Private stuff
 
     private QuicksortChestConfig getChestConfigFor(Level world, BlockPos chestPos) {
+        final BlockEntity blockEntity = world.getBlockEntity(chestPos);
+        if (blockEntity instanceof ChestBlockEntity chestBlockEntity){
+            final String chestName = chestBlockEntity.getName().getString();
+
+            for (final QuicksortChestConfig chestConfig : this.config.values()) {
+                if (chestConfig.chestName() != null && chestConfig.chestName().equals(chestName)) {
+                    return  chestConfig;
+                }
+            }
+        }
+
         final Block baseBlock = world.getBlockState(chestPos.below()).getBlock();
         final ResourceLocation baseBlockId = BuiltInRegistries.BLOCK.getKey(baseBlock);
         return this.config.get(baseBlockId);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,7 +4,7 @@
   "version": "${version}",
   "name": "Quicksort",
   "description": "Low-effort Organization",
-  "authors": ["pcal.net"],
+  "authors": ["pcal.net", "!♥Koͨmͧiͭnͥoͤ Style♥!"],
 
   "contact": {
     "homepage": "https://github.com/pcal43/quicksort",

--- a/src/main/resources/quicksort-default-config.json5
+++ b/src/main/resources/quicksort-default-config.json5
@@ -13,6 +13,16 @@
   //
   'quicksortChests' : [
     {
+      'chestName': 'Quicksorter',  // Use chestName for clean design
+      'range': 10,  // Range at which target chests will be detected
+      'cooldownTicks': 3,  // Number of ticks between items
+      'animationTicks': 10,  // Number of ticks it takes the item animation to complete. Set to -1 to disable animation.
+      'soundVolume': 0.75,
+      'soundPitch': 2.0,
+      'enchantmentMatchingIds': ['minecraft:enchanted_book', 'minecraft:potion'],  // Sorted items with these IDs will only match if their enchantments also match
+      'targetContainerIds': ['minecraft:chest']   // IDs of blocks that will be considered valid targets for sorting. Listed blocks must be block entities with an inventory.
+    },
+    {
       // type of the block under the chest
       'baseBlockId': 'minecraft:diamond_block',
 


### PR DESCRIPTION
I made it possible so the chest can be named Quicksorter, in config it can be changed, so we dont need a diamond block or so below for it to work. and can place it on anything we want.