### PR TITLE
Fabric 26.1

### DIFF
--- a/.github/release-notes/v0.22.0.md
+++ b/.github/release-notes/v0.22.0.md
@@ -1,0 +1,64 @@
+## Release
+
+- Mod: `Quicksort`
+- Loader: `Fabric`
+- Minecraft: `26.1`
+- Version: `0.22.0+26.1`
+- Java: `25`
+
+## Dependencies
+
+- Updated Fabric Loader target to `0.19.2`.
+- Updated Fabric API target for Minecraft `26.1`.
+- Added Cloth Config API `26.1.154`.
+- Added Mod Menu `18.0.0-alpha.8` integration.
+
+## Configuration
+
+- Added Cloth Config screen through Mod Menu.
+- Added configurable quicksort chest entries for:
+  - `minecraft:iron_block` with radius `5`.
+  - `minecraft:copper_block` with radius `5`.
+  - `minecraft:gold_block` with radius `10`.
+  - `minecraft:emerald_block` with radius `25`.
+  - `minecraft:diamond_block` with radius `50`.
+  - `minecraft:netherite_block` with radius `100`.
+- Added fallback/migration behavior so older configs inherit missing values from defaults.
+- Changed `logLevel` in Mod Menu to a selector to avoid crashes from blank text input.
+
+## Sorting Behavior
+
+- Added obstruction checking with `checkObstructions`.
+- Rechecks obstruction during transfer attempts, not only when a job is created.
+- Added `transferMode`:
+  - `ITEMS`: transfers up to `transferAmount` items per item type each cooldown cycle.
+  - `STACKS`: transfers up to `transferAmount` stacks total each cooldown cycle.
+- Added `transferAmount`.
+- Added `continueWhileOpen`.
+- Jobs with `continueWhileOpen=true` can keep processing while the source chest GUI is open.
+- Jobs now re-check source slots during processing, so newly added items can be picked up while the job is still active.
+
+## Redstone
+
+- Added `enableRedstoneActivation`.
+- Redstone activation starts on a rising edge after the world is loaded.
+- If redstone remains powered and no job is active, the mod can retry after a short delay instead of requiring manual chest interaction.
+- The mod avoids starting duplicate jobs for the same quicksort chest.
+
+## Animation And Sound
+
+- Fixed transfer sound playback by decoupling it from visual animation.
+- Added `animationMode`:
+  - `PARTICLE` is the default and safest mode.
+  - `ENTITY` keeps the old flying-item style with temporary non-saving item entities.
+- Entity animation ghosts are tracked and discarded when jobs stop or runtime state resets.
+
+## Stability Notes
+
+- Automatic resume on world load is disabled.
+- Reason: starting sorting jobs while the world is still loading can block integrated server spawn loading and leave the game stuck at `Preparing spawn area: 16%`.
+- This means an unfinished sorting process is not automatically resumed just because the save was opened again.
+- After entering the world, sorting starts through normal triggers:
+  - close the source chest, or
+  - toggle redstone from off to on when `enableRedstoneActivation=true`.
+- A redstone source that is already powered while the world loads is recorded as the initial state and does not start sorting until it changes off and back on.

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -1,25 +1,38 @@
-# Used when building external pull requests
-# We don't want to publish build artifacts or expose our other caches to possibly untrusted code
+# Used when building external pull requests.
+# This workflow only validates the Gradle build and does not publish artifacts.
 name: build-pull-request
 
-on: [ pull_request ]
+on:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v3
-      - uses: actions/setup-java@v4
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: setup jdk
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: '25'
+          cache: gradle
 
-      - name: Setup Gradle
+      - name: setup gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
 
-      - name: Execute Gradle build
+      - name: make gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: build
         run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,11 @@ jobs:
       - name: derive release version
         shell: bash
         run: |
-          MOD_VERSION="$(grep '^mod_version=' gradle.properties | cut -d'=' -f2)"
+          MOD_VERSION="$(awk -F= '/^[[:space:]]*mod_version[[:space:]]*=/{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' gradle.properties)"
+          if [ -z "$MOD_VERSION" ]; then
+            echo "Unable to find mod_version in gradle.properties" >&2
+            exit 1
+          fi
           RELEASE_VERSION="${MOD_VERSION%%+*}"
           echo "MOD_VERSION=${MOD_VERSION}" >> "$GITHUB_ENV"
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: release
+
+on:
+  push:
+    branches:
+      - 'Fabric-26.1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: setup jdk
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: make gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: build
+        run: ./gradlew build
+
+      - name: derive release version
+        shell: bash
+        run: |
+          MOD_VERSION="$(grep '^mod_version=' gradle.properties | cut -d'=' -f2)"
+          RELEASE_VERSION="${MOD_VERSION%%+*}"
+          echo "MOD_VERSION=${MOD_VERSION}" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=v${RELEASE_VERSION}" >> "$GITHUB_ENV"
+
+      - name: prepare release notes
+        shell: bash
+        run: |
+          NOTES_FILE=".github/release-notes/${RELEASE_TAG}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            cp "$NOTES_FILE" release-notes.md
+          else
+            cat > release-notes.md <<EOF
+          ## Release
+
+          - Loader: \`Fabric\`
+          - Version: \`${MOD_VERSION}\`
+          - Branch: \`${GITHUB_REF_NAME}\`
+
+          ## Changelog
+
+          - Automated Quicksort release for Minecraft 26.1.
+          EOF
+          fi
+
+      - name: publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          target_commitish: ${{ github.sha }}
+          name: Quicksort Fabric ${{ env.MOD_VERSION }}
+          body_path: release-notes.md
+          files: |
+            build/libs/*.jar

--- a/README.md
+++ b/README.md
@@ -1,45 +1,132 @@
 # Quicksort
 
+Quicksort is a vanilla-friendly item sorting mod for Fabric. It does not add new blocks; a regular chest becomes a quicksort chest based on the block placed underneath it.
+
+## Version
+
+- Minecraft: `26.1`
+- Loader: `Fabric`
+- Mod version: `0.22.0+26.1`
+- Java: `25`
+
+## Dependencies
+
+- Fabric Loader `0.19.2` or newer
+- Fabric API for Minecraft `26.1`
+- Cloth Config API `26.1.154`
+- Mod Menu `18.0.0-alpha.8` is optional, but recommended for editing the config in-game
+
 ## Features
-* **Lightweight item sorting.** Keep your workshop organized quickly and easily.
-* **Vanilla-friendly**.         Does not add any new blocks to your server.
-* **Serverside-only**.          Does not have to be installed on clients.
-* **Fully customizable.**       Define your own quicksort chest types.
+
+- Lightweight item sorting using vanilla chests.
+- Configurable quicksort chest types and ranges.
+- Config screen through Mod Menu and Cloth Config.
+- Optional obstruction checks between the source chest and target chests.
+- Transfer by individual item counts or by stack counts.
+- Optional redstone activation.
+- Optional processing while the source chest is open.
+- Configurable sound volume, pitch, cooldown, and animation mode.
 
 ## Usage
-* Place an emerald or diamond block in the center of your storage area.
-* Create a **Quicksorter** by putting regular chest on top of that block.
-* Items placed in the Quicksorter will automatically be distributed to nearby chests that contain matching items.
+
+1. Place one of the configured base blocks in your storage area.
+2. Place a regular chest on top of that block. This chest becomes the quicksort chest.
+3. Place matching items in nearby target chests.
+4. Put items into the quicksort chest.
+5. Close the quicksort chest to start sorting, or toggle redstone from off to on if redstone activation is enabled for that base block.
+
+Items are sent to nearby configured target containers that already contain matching items or have room for a matching stack.
 
 ![](https://github.com/pcal43/quicksort/raw/main/etc/quicksort-demo2.gif)
 
+## Default Base Blocks
 
-## Fine Points
-* The Quicksorter must have a clear line-of-sight to the receiving chests
-* The receiving chests must be within a cube-shaped area centered on the Quicksorter.
-* The Quicksorter's range depends on the type of block used:
-  * Emerald: 5 blocks away
-  * Diamond: 10 blocks away
-* Items are transferred regardless of whether the item appears to not make it to the chest
+The default configuration includes:
+
+- Iron block: radius `5`
+- Copper block: radius `5`
+- Gold block: radius `10`
+- Emerald block: radius `25`
+- Diamond block: radius `50`
+- Netherite block: radius `100`
+
+These values can be edited in the config file or through Mod Menu.
 
 ## Configuration
 
-To configure the mod, follow the instructions in the default config file:
+The default config is stored at:
 
-https://github.com/pcal43/quicksort/blob/main/src/main/resources/quicksort-default-config.json5
+`src/main/resources/quicksort-default-config.json5`
+
+At runtime, the generated config is:
+
+`config/quicksort.json5`
+
+Important options:
+
+- `range`: cube radius used to find target containers.
+- `cooldownTicks`: ticks between transfer attempts.
+- `animationTicks`: animation duration. Use `-1` to disable animation.
+- `animationMode`: `PARTICLE` or `ENTITY`. `PARTICLE` is the default and safest mode.
+- `soundVolume`: transfer sound volume.
+- `soundPitch`: transfer sound pitch.
+- `checkObstructions`: when true, solid blocks between the quicksort chest and target container block that transfer.
+- `transferMode`: `ITEMS` or `STACKS`.
+- `transferAmount`: amount used by the selected transfer mode each cooldown cycle.
+- `enableRedstoneActivation`: starts sorting when the base block receives a redstone rising edge.
+- `continueWhileOpen`: keeps sorting while the quicksort chest is open.
+- `enchantmentMatchingIds`: item ids that only match when enchantments/components also match.
+- `targetContainerIds`: block ids that can receive sorted items.
+
+Older config files can omit newly added values; missing values inherit from defaults.
+
+## Transfer Modes
+
+`ITEMS` sends up to `transferAmount` items per item type each cooldown cycle.
+
+Example: with `transferAmount: 5`, ten different item types can each send five items, for a total of fifty items in that cycle.
+
+`STACKS` sends up to `transferAmount` stacks total each cooldown cycle.
+
+Example: with `transferAmount: 5`, only five stacks are transferred in that cycle, even if the quicksort chest contains more item types.
+
+## Redstone Behavior
+
+When `enableRedstoneActivation` is true, sorting starts when the base block changes from unpowered to powered.
+
+The mod avoids creating duplicate jobs for the same quicksort chest. If redstone remains powered and no job is active, the mod can retry after a short delay. However, redstone that is already powered while the world loads is treated as the initial state and does not start sorting automatically.
+
+## World Load Behavior
+
+Quicksort does not resume unfinished sorting jobs automatically when a world loads.
+
+This is intentional. Starting sorting jobs while the integrated server is still loading chunks can block spawn loading and leave Minecraft stuck at `Preparing spawn area: 16%`.
+
+After entering the world, start sorting through normal triggers:
+
+- close the quicksort chest, or
+- toggle redstone from off to on when `enableRedstoneActivation` is enabled.
+
+## Notes
+
+- Target containers must be loaded and within the configured cube radius.
+- If `checkObstructions` is enabled, the path is checked when a target is found and again during transfer attempts.
+- Other quicksort chests are skipped as sorting targets.
+- The `ENTITY` animation mode uses temporary non-saving item entities. Use `PARTICLE` if you want the safest behavior.
 
 ## Credits
 
-#### Icon components courtesy of
-* [Minecraft Toolbox - Minecraft Chest PNG](https://flyclipart.com/minecraft-toolbox-minecraft-chest-png-50783)
-* [transparentpng.com](https://www.transparentpng.com/download/circle-vector-2_15270.html)
-* [freesvg.org](https://freesvg.org/8-directions-arrows)
+Icon components courtesy of:
+
+- [Minecraft Toolbox - Minecraft Chest PNG](https://flyclipart.com/minecraft-toolbox-minecraft-chest-png-50783)
+- [transparentpng.com](https://www.transparentpng.com/download/circle-vector-2_15270.html)
+- [freesvg.org](https://freesvg.org/8-directions-arrows)
 
 ## Legal
 
 This mod is published under the [MIT License](LICENSE).
 
-You're free to include this mod in your modpack provided you attribute it to pcal.net.
+You are free to include this mod in your modpack provided you attribute it to pcal.net.
 
 ## Questions?
 
@@ -47,4 +134,4 @@ If you have questions about this mod, please join the Discord server:
 
 [https://discord.pcal.net](https://discord.pcal.net)
 
-Comments have been disabled and I will **not** reply to private messages on Curseforge.
+Comments have been disabled and I will not reply to private messages on CurseForge.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.14-SNAPSHOT'
+	id 'net.fabricmc.fabric-loom' version "${loom_version}"
 	id "com.modrinth.minotaur" version "2.+"
 	id 'net.darkhax.curseforgegradle' version '1.1.25'
 }
@@ -14,6 +14,8 @@ repositories {
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
 	maven { url 'https://maven.nucleoid.xyz' }
+	maven { url 'https://maven.shedaniel.me/' }
+	maven { url 'https://maven.terraformersmc.com/releases/' }
 }
 
 
@@ -25,9 +27,10 @@ configurations {
 dependencies {
 	// Fabric & Minecraft
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings loom.officialMojangMappings()
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}"
+	implementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 
 	// JUnit
 	testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
@@ -52,8 +55,8 @@ sourceSets.test {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
-	it.options.release = 17
+	// Minecraft 26.1 development requires Java 25.
+	it.options.release = 25
 }
 
 java {
@@ -61,6 +64,9 @@ java {
 	// if it is present.
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {
@@ -76,12 +82,14 @@ modrinth {
 	projectId = "${project.modrinth_projectId}"
 	versionNumber = project.mod_version
 	versionType = "Release"
-	uploadFile = remapJar
+	uploadFile = jar
 	changelog = "<p><a href='${project.github_projectUrl}/releases/tag/${project.mod_version}'>${project.github_projectUrl}/releases/tag/${project.mod_version}</a></p>"
 	gameVersions = ["${project.minecraft_version}"]
 	loaders = ["fabric"]
 	dependencies {
 		required.project "fabric-api"
+		optional.project "cloth-config"
+		optional.project "modmenu"
 	}
 }
 
@@ -93,7 +101,7 @@ tasks.register('publishCurseForge', TaskPublishCurseForge) {
 
 	// Configure the main artifact
 	// The plugin automatically detects Fabric & Java version from your Loom setup
-	def mainFile = upload(project.curseforge_projectId, remapJar)
+	def mainFile = upload(project.curseforge_projectId, jar)
 
 	mainFile.releaseType = "release"
 	mainFile.changelog = "${project.github_projectUrl}/releases/tag/${project.mod_version}"
@@ -102,8 +110,8 @@ tasks.register('publishCurseForge', TaskPublishCurseForge) {
 	mainFile.addGameVersion(project.minecraft_version)
 	mainFile.addModLoader("Fabric")
 
-	// Ensure remapJar is finished before this runs
-	dependsOn(remapJar)
+	// Ensure jar is finished before this runs
+	dependsOn(jar)
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,14 +9,17 @@ curseforge_projectId = 641431
 
 
 # Quicksort mod
-mod_version = 0.21.1+1.21.11-prerelease
+mod_version = 0.22.0+26.1
 maven_group = net.pcal
 archives_base_name = quicksort
 
 # Fabric & Minecraft
 # https://fabricmc.net/develop
-minecraft_version=1.21.11
-loader_version=0.18.4
-fabric_version=0.141.1+1.21.11
+minecraft_version=26.1
+loader_version=0.19.2
+loom_version=1.16-SNAPSHOT
+fabric_version=0.145.1+26.1
+cloth_config_version=26.1.154
+modmenu_version=18.0.0-alpha.8
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/pcal/quicksort/GhostItemEntity.java
+++ b/src/main/java/net/pcal/quicksort/GhostItemEntity.java
@@ -8,92 +8,82 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 
 /**
- * These are the 'ghost' entities that fly from the quicksorter to the target chests when sorting is happening.
- * They disable collision checking and other normal ItemEntity behaviors - they are intended to solely be visual
- * artifacts.
+ * Temporary visual item used by animationMode ENTITY.
  */
 public class GhostItemEntity extends ItemEntity {
 
-    public GhostItemEntity(Level world, double d, double e, double f, ItemStack stack) {
-        super(world, d, e, f, stack);
+    private final int lifetimeTicks;
+    private int quicksortAge = 0;
+
+    public GhostItemEntity(Level world, double x, double y, double z, ItemStack stack, int lifetimeTicks) {
+        super(world, x, y, z, stack);
+        this.lifetimeTicks = Math.max(1, lifetimeTicks);
+        setPickUpDelay(Integer.MAX_VALUE);
     }
 
-    /**
-     * This prevents players from being able to pick up the ghost items.
-     */
     @Override
-    public void playerTouch(Player player) {}
+    public void tick() {
+        baseTick();
+        final Vec3 movement = getDeltaMovement();
+        setPos(getX() + movement.x(), getY() + movement.y(), getZ() + movement.z());
+        setOnGround(false);
+        if (++this.quicksortAge > this.lifetimeTicks) discard();
+    }
 
-    /**
-     * The prevents hoppers from pulling the ghost items.  Also seems to block some advancement-related code.
-     */
     @Override
-    public boolean isAlive() { return false; }
+    public void playerTouch(Player player) {
+    }
 
-    /**
-     * Prevents ghosts from catching fire if they travel through lava (which evidently doesn't block line-of-sight).
-     * There's actually not any harm if they are on fire.  Just seems like the right thing.
-     */
     @Override
-    public boolean fireImmune() { return true; }
+    public boolean fireImmune() {
+        return true;
+    }
 
-    /**
-     * I don't think this actually does anything.
-     */
     @Override
-    public boolean isIgnoringBlockTriggers() { return true;} 
+    public boolean isIgnoringBlockTriggers() {
+        return true;
+    }
 
-    /**
-     * I don't think this actually does anything.
-     */
     @Override
-    public boolean isAffectedByBlocks() { return false; }
+    public boolean isAffectedByBlocks() {
+        return false;
+    }
 
-    /**
-     * I don't think this actually does anything.
-     */
     @Override
-    public boolean isColliding(BlockPos pos, BlockState state) { return false; }
+    public boolean isColliding(BlockPos pos, BlockState state) {
+        return false;
+    }
 
-    /**
-     * I don't think this actually does anything.
-     */
     @Override
-    public boolean isInWall() { return false; }
+    public boolean isInWall() {
+        return false;
+    }
 
-    /**
-     * Seems like a no.
-     */
     @Override
-    public boolean shouldPlayLavaHurtSound() { return false; }
+    public boolean shouldPlayLavaHurtSound() {
+        return false;
+    }
 
-    /**
-     * Seems like a no.
-     */
     @Override
-	public boolean ignoreExplosion(Explosion explosion) { return true; }
-    
-    /**
-     * I don't think this actually does anything.
-     */
-    @Override    
-    public boolean canCollideWith(Entity e) { return false; }
+    public boolean ignoreExplosion(Explosion explosion) {
+        return true;
+    }
 
-    /**
-     * I don't think this actually does anything.
-     */
-    @Override    
-    public boolean isFree(double offsetX, double offsetY, double offsetZ) { return true; }
+    @Override
+    public boolean canCollideWith(Entity entity) {
+        return false;
+    }
 
-    /**
-     * Don't save the ghosts.  Otherwise, the item is effectively duplicated if the chunk is unloaded while
-     * the ghost is in flight.
-     */
+    @Override
+    public boolean isFree(double offsetX, double offsetY, double offsetZ) {
+        return true;
+    }
+
     @Override
     public boolean shouldBeSaved() {
         return false;
     }
 }
-

--- a/src/main/java/net/pcal/quicksort/QuicksortConfig.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortConfig.java
@@ -10,14 +10,45 @@ public record QuicksortConfig(
         List<QuicksortChestConfig> chestConfigs,
         Level logLevel
 ) {
+    public enum TransferMode {
+        ITEMS,
+        STACKS;
+
+        public static TransferMode parse(String value) {
+            if (value == null) return null;
+            for (TransferMode mode : values()) {
+                if (mode.name().equalsIgnoreCase(value.trim())) return mode;
+            }
+            throw new IllegalArgumentException("Invalid transferMode " + value);
+        }
+    }
+
+    public enum AnimationMode {
+        PARTICLE,
+        ENTITY;
+
+        public static AnimationMode parse(String value) {
+            if (value == null) return null;
+            for (AnimationMode mode : values()) {
+                if (mode.name().equalsIgnoreCase(value.trim())) return mode;
+            }
+            throw new IllegalArgumentException("Invalid animationMode " + value);
+        }
+    }
 
     public record QuicksortChestConfig(
             Identifier baseBlockId,
             int range,
             int cooldownTicks,
             int animationTicks,
+            AnimationMode animationMode,
             float soundVolume,
             float soundPitch,
+            boolean checkObstructions,
+            TransferMode transferMode,
+            int transferAmount,
+            boolean enableRedstoneActivation,
+            boolean continueWhileOpen,
             Set<Identifier> enchantmentMatchingIds,
             Set<Identifier> targetContainerIds
     ) {

--- a/src/main/java/net/pcal/quicksort/QuicksortConfigManager.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortConfigManager.java
@@ -1,0 +1,67 @@
+package net.pcal.quicksort;
+
+import org.apache.logging.log4j.Logger;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+import static net.pcal.quicksort.QuicksortService.LOG_PREFIX;
+
+final class QuicksortConfigManager {
+
+    private static final String DEFAULT_CONFIG_RESOURCE_NAME = "quicksort-default-config.json5";
+    private static final String CONFIG_FILENAME = "quicksort.json5";
+
+    private QuicksortConfigManager() {
+    }
+
+    static Path getConfigPath() {
+        return Paths.get("config", CONFIG_FILENAME);
+    }
+
+    static QuicksortConfig loadOrCreate(Logger logger) throws IOException {
+        final Path configDirPath = Paths.get("config");
+        final Path configFilePath = getConfigPath();
+        if (!configFilePath.toFile().exists()) {
+            logger.info(LOG_PREFIX + "Writing default configuration to " + configFilePath);
+            try (final InputStream in = openDefaultConfig()) {
+                Files.createDirectories(configDirPath);
+                Files.copy(in, configFilePath, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+        return load();
+    }
+
+    static QuicksortConfig load() throws IOException {
+        final QuicksortConfig defaultConfig = loadDefault();
+        try (final InputStream in = new FileInputStream(getConfigPath().toFile())) {
+            return QuicksortConfigParser.parse(in, defaultConfig.chestConfigs().get(0));
+        }
+    }
+
+    static QuicksortConfig loadDefault() throws IOException {
+        try (final InputStream in = openDefaultConfig()) {
+            return QuicksortConfigParser.parse(in, null);
+        }
+    }
+
+    static void save(QuicksortConfig config) throws IOException {
+        final Path configPath = getConfigPath();
+        Files.createDirectories(configPath.getParent());
+        try (final OutputStream out = Files.newOutputStream(configPath)) {
+            QuicksortConfigParser.write(config, out);
+        }
+    }
+
+    private static InputStream openDefaultConfig() {
+        final InputStream in = QuicksortConfigManager.class.getClassLoader().getResourceAsStream(DEFAULT_CONFIG_RESOURCE_NAME);
+        if (in == null) throw new IllegalStateException("Unable to load " + DEFAULT_CONFIG_RESOURCE_NAME);
+        return in;
+    }
+}

--- a/src/main/java/net/pcal/quicksort/QuicksortConfigParser.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortConfigParser.java
@@ -2,17 +2,21 @@ package net.pcal.quicksort;
 
 import com.google.gson.Gson;
 import net.minecraft.resources.Identifier;
+import net.pcal.quicksort.QuicksortConfig.AnimationMode;
 import net.pcal.quicksort.QuicksortConfig.QuicksortChestConfig;
+import net.pcal.quicksort.QuicksortConfig.TransferMode;
 import org.apache.logging.log4j.Level;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -33,13 +37,21 @@ class QuicksortConfigParser {
                     chestGson.range,
                     chestGson.cooldownTicks,
                     chestGson.animationTicks,
+                    chestGson.animationMode,
                     chestGson.soundVolume,
                     chestGson.soundPitch,
+                    chestGson.checkObstructions,
+                    chestGson.transferMode,
+                    chestGson.transferAmount,
+                    chestGson.enableRedstoneActivation,
+                    chestGson.continueWhileOpen,
                     chestGson.nbtMatchEnabledIds != null ? chestGson.nbtMatchEnabledIds : chestGson.enchantmentMatchingIds,
                     chestGson.targetContainerIds));
         }
         // adjust logging to configured level
-        final String configuredLevel = configGson.logLevel;
+        final String configuredLevel = configGson.logLevel == null || configGson.logLevel.isBlank() ?
+                Level.INFO.toString() :
+                configGson.logLevel.trim().toUpperCase();
         final Level logLevel = Level.getLevel(configuredLevel);
         if (logLevel == null) throw new IllegalArgumentException("Invalid logLevel " + configuredLevel);
         return new QuicksortConfig(Collections.unmodifiableList(chests), logLevel);
@@ -51,10 +63,20 @@ class QuicksortConfigParser {
             Integer range,
             Integer cooldownTicks,
             Integer animationTicks,
+            String animationMode,
             Float soundVolume,
             Float soundPitch,
+            Boolean checkObstructions,
+            String transferMode,
+            Integer transferAmount,
+            Boolean enableRedstoneActivation,
+            Boolean continueWhileOpen,
             Collection<String> enchantmentMatchingIds,
             Collection<String> targetContainerIds) {
+        final Integer resolvedTransferAmount = requireNonNull(
+                transferAmount != null ? transferAmount : dflt == null ? null : dflt.transferAmount(),
+                "transferAmount is required");
+        if (resolvedTransferAmount < 1) throw new IllegalArgumentException("transferAmount must be at least 1");
         return new QuicksortChestConfig(
                 Identifier.parse(requireNonNull(baseBlockId, "baseBlockId is required")),
                 requireNonNull(range != null ? range : dflt == null ? null : dflt.range(),
@@ -63,10 +85,21 @@ class QuicksortConfigParser {
                         "cooldownTicks is required"),
                 requireNonNull(animationTicks != null ? animationTicks : dflt == null ? null : dflt.animationTicks(),
                         "animationTicks is required"),
+                requireNonNull(animationMode != null ? AnimationMode.parse(animationMode) : dflt == null ? null : dflt.animationMode(),
+                        "animationMode is required"),
                 requireNonNull(soundVolume != null ? soundVolume : dflt == null ? null : dflt.soundVolume(),
                         "soundVolume is required"),
                 requireNonNull(soundPitch != null ? soundPitch : dflt == null ? null : dflt.soundPitch(),
                         "soundPitch is required"),
+                requireNonNull(checkObstructions != null ? checkObstructions : dflt == null ? null : dflt.checkObstructions(),
+                        "checkObstructions is required"),
+                requireNonNull(transferMode != null ? TransferMode.parse(transferMode) : dflt == null ? null : dflt.transferMode(),
+                        "transferMode is required"),
+                resolvedTransferAmount,
+                requireNonNull(enableRedstoneActivation != null ? enableRedstoneActivation : dflt == null ? null : dflt.enableRedstoneActivation(),
+                        "enableRedstoneActivation is required"),
+                requireNonNull(continueWhileOpen != null ? continueWhileOpen : dflt == null ? null : dflt.continueWhileOpen(),
+                        "continueWhileOpen is required"),
                 requireNonNull(enchantmentMatchingIds != null ? toIdentifierSet(enchantmentMatchingIds) : dflt == null ? null : dflt.enchantmentMatchingIds(),
                         "enchantmentMatchingIds"),
                 requireNonNull(targetContainerIds != null ? toIdentifierSet(targetContainerIds) : dflt == null ? null : dflt.targetContainerIds(),
@@ -78,6 +111,93 @@ class QuicksortConfigParser {
         final Set<Identifier> set = new HashSet<>();
         for (String id : enchantmentMatchingIds) set.add(Identifier.parse(id));
         return set;
+    }
+
+    static void write(QuicksortConfig config, OutputStream out) throws IOException {
+        out.write(toJson5(config).getBytes(StandardCharsets.UTF_8));
+    }
+
+    static String toJson5(QuicksortConfig config) {
+        final StringBuilder out = new StringBuilder();
+        out.append("//\n");
+        out.append("// Quicksort configuration file\n");
+        out.append("//\n");
+        out.append("// This file is parsed as JSON5-like JSON after lines starting with // are removed.\n");
+        out.append("//\n\n");
+        out.append("{\n");
+        out.append("  // List of quicksort chest types. The type is selected by the block under the chest.\n");
+        out.append("  // Later entries can omit values and inherit them from the previous entry.\n");
+        out.append("  'quicksortChests' : [\n");
+        final List<QuicksortChestConfig> chests = config.chestConfigs();
+        for (int i = 0; i < chests.size(); i++) {
+            final QuicksortChestConfig chest = chests.get(i);
+            out.append("    {\n");
+            out.append("      // Block id under the quicksort chest.\n");
+            appendString(out, "baseBlockId", chest.baseBlockId().toString(), true);
+            out.append("\n      // Cube radius where target containers are detected.\n");
+            appendNumber(out, "range", chest.range(), true);
+            out.append("\n      // Number of ticks between transfer attempts.\n");
+            appendNumber(out, "cooldownTicks", chest.cooldownTicks(), true);
+            out.append("\n      // Ticks for the item animation. Use -1 to disable animation.\n");
+            appendNumber(out, "animationTicks", chest.animationTicks(), true);
+            out.append("\n      // Animation renderer. PARTICLE is the default and safest. ENTITY uses temporary item entities.\n");
+            appendString(out, "animationMode", chest.animationMode().name(), true);
+            out.append("\n      // Volume of the transfer sound.\n");
+            appendNumber(out, "soundVolume", chest.soundVolume(), true);
+            out.append("\n      // Pitch of the transfer sound.\n");
+            appendNumber(out, "soundPitch", chest.soundPitch(), true);
+            out.append("\n      // If true, solid blocks between the quicksorter and target container will block transfers.\n");
+            appendBoolean(out, "checkObstructions", chest.checkObstructions(), true);
+            out.append("\n      // ITEMS sends up to transferAmount items per item type each cycle. STACKS sends up to transferAmount stacks total.\n");
+            appendString(out, "transferMode", chest.transferMode().name(), true);
+            out.append("\n      // Amount used by transferMode each time cooldownTicks elapses.\n");
+            appendNumber(out, "transferAmount", chest.transferAmount(), true);
+            out.append("\n      // If true, a redstone rising edge on the base block starts sorting automatically.\n");
+            appendBoolean(out, "enableRedstoneActivation", chest.enableRedstoneActivation(), true);
+            out.append("\n      // If true, sorting continues while the quicksort chest is open.\n");
+            appendBoolean(out, "continueWhileOpen", chest.continueWhileOpen(), true);
+            out.append("\n      // Item ids that only match when enchantments/components also match.\n");
+            appendStringList(out, "enchantmentMatchingIds", chest.enchantmentMatchingIds(), true);
+            out.append("\n      // Block ids that are valid sorting targets. They must be block entities with inventories.\n");
+            appendStringList(out, "targetContainerIds", chest.targetContainerIds(), false);
+            out.append("\n    }");
+            if (i < chests.size() - 1) out.append(",");
+            out.append("\n");
+        }
+        out.append("  ],\n\n");
+        out.append("  'logLevel' : '").append(config.logLevel()).append("'\n");
+        out.append("}\n");
+        return out.toString();
+    }
+
+    private static void appendString(StringBuilder out, String name, String value, boolean comma) {
+        out.append("      '").append(name).append("': '").append(value).append("'");
+        if (comma) out.append(",");
+        out.append("\n");
+    }
+
+    private static void appendNumber(StringBuilder out, String name, Number value, boolean comma) {
+        out.append("      '").append(name).append("': ").append(value);
+        if (comma) out.append(",");
+        out.append("\n");
+    }
+
+    private static void appendBoolean(StringBuilder out, String name, boolean value, boolean comma) {
+        out.append("      '").append(name).append("': ").append(value);
+        if (comma) out.append(",");
+        out.append("\n");
+    }
+
+    private static void appendStringList(StringBuilder out, String name, Collection<Identifier> values, boolean comma) {
+        out.append("      '").append(name).append("': [");
+        final List<String> sorted = values.stream().map(Identifier::toString).sorted(Comparator.naturalOrder()).toList();
+        for (int i = 0; i < sorted.size(); i++) {
+            if (i > 0) out.append(", ");
+            out.append("'").append(sorted.get(i)).append("'");
+        }
+        out.append("]");
+        if (comma) out.append(",");
+        out.append("\n");
     }
 
     // ===================================================================================
@@ -106,8 +226,14 @@ class QuicksortConfigParser {
         Integer range;
         Integer cooldownTicks;
         Integer animationTicks;
+        String animationMode;
         Float soundVolume;
         Float soundPitch;
+        Boolean checkObstructions;
+        String transferMode;
+        Integer transferAmount;
+        Boolean enableRedstoneActivation;
+        Boolean continueWhileOpen;
         List<String> enchantmentMatchingIds;
         List<String> targetContainerIds;
 

--- a/src/main/java/net/pcal/quicksort/QuicksortInitializer.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortInitializer.java
@@ -1,81 +1,105 @@
 package net.pcal.quicksort;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 
 import static net.pcal.quicksort.QuicksortService.LOGGER_NAME;
 import static net.pcal.quicksort.QuicksortService.LOG_PREFIX;
 
 public class QuicksortInitializer implements ModInitializer {
 
-    // ===================================================================================
-    // Constants
-
-    private static final String DEFAULT_CONFIG_RESOURCE_NAME = "quicksort-default-config.json5";
-    private static final String CONFIG_FILENAME = "quicksort.json5";
-
-    // ===================================================================================
-    // ModInitializer implementation
+    private static final Logger LOG = LogManager.getLogger(LOGGER_NAME);
 
     @Override
     public void onInitialize() {
+        LOG.info(LOG_PREFIX + "=== Quicksort mod initializing ===");
         try {
             initialize();
+            LOG.info(LOG_PREFIX + "=== Quicksort mod initialized successfully ===");
         } catch (IOException ioe) {
+            LOG.error(LOG_PREFIX + "Failed to initialize Quicksort mod", ioe);
             throw new RuntimeException(ioe);
         }
     }
 
-    // ===================================================================================
-    // Private
-
     private void initialize() throws IOException {
-        Logger logger = LogManager.getLogger(LOGGER_NAME);
+        final Logger logger = LogManager.getLogger(LOGGER_NAME);
 
-        final Path configDirPath = Paths.get("config");
+        LOG.info(LOG_PREFIX + "Loading configuration from " + QuicksortConfigManager.getConfigPath());
+        final QuicksortConfig config = QuicksortConfigManager.loadOrCreate(logger);
+        LOG.info(LOG_PREFIX + "Loaded " + config.chestConfigs().size() + " chest configs, logLevel=" + config.logLevel());
+        applyConfig(config, logger);
 
-        //
-        // Always write out the default config to the .disabled so the can rename/edit it if they want.
-        //
-        final Path configFilePath = Paths.get("config", CONFIG_FILENAME);
-        final QuicksortConfig config;
-        // If they don't have a config file, create a default one that they can edit later
-        if (!configFilePath.toFile().exists()) {
-            logger.info(LOG_PREFIX + "Writing default configuration to " + configFilePath);
-            try (final InputStream in = QuicksortInitializer.class.getClassLoader().getResourceAsStream(DEFAULT_CONFIG_RESOURCE_NAME)) {
-                if (in == null) throw new IllegalStateException("Unable to load " + DEFAULT_CONFIG_RESOURCE_NAME);
-                java.nio.file.Files.createDirectories(configDirPath); // dir doesn't exist on fresh install
-                java.nio.file.Files.copy(in, configFilePath, StandardCopyOption.REPLACE_EXISTING);
-            }
-        }
-        // Load the default config from our resource path.  We'll use the values here as defaults for loading their config.
-        // This will allow us to more easily add new configuration values without breaking existing configs.
-        final QuicksortConfig defaultConfig;
-        try (final InputStream in = QuicksortInitializer.class.getClassLoader().getResourceAsStream(DEFAULT_CONFIG_RESOURCE_NAME)) {
-            defaultConfig = QuicksortConfigParser.parse(in, null);
-        }
-        logger.info(LOG_PREFIX + "Loading configuration from " + configFilePath);
-        try (final InputStream in = new FileInputStream(configFilePath.toFile())) {
-            // parse the config file using the first chest config from our embedded defaults as the default
-            config = QuicksortConfigParser.parse(in, defaultConfig.chestConfigs().get(0));
-        }
-        if (config.logLevel() != Level.INFO) {
-            Configurator.setLevel(LOGGER_NAME, config.logLevel());
-            logger.info(LOG_PREFIX + "LogLevel set to " + config.logLevel());
-        }
+        LOG.info(LOG_PREFIX + "Registering SERVER_STARTING event");
+        ServerLifecycleEvents.SERVER_STARTING.register(this::onServerStarting);
+
+        LOG.info(LOG_PREFIX + "Registering SERVER_STARTED event");
+        ServerLifecycleEvents.SERVER_STARTED.register(this::onServerStarted);
+
+        LOG.info(LOG_PREFIX + "Registering SERVER_STOPPING event");
+        ServerLifecycleEvents.SERVER_STOPPING.register(this::onServerStopping);
+
+        LOG.info(LOG_PREFIX + "Registering SERVER_STOPPED event");
+        ServerLifecycleEvents.SERVER_STOPPED.register(this::onServerStopped);
+
+        LOG.info(LOG_PREFIX + "Registering BLOCK_ENTITY_LOAD event");
+        ServerBlockEntityEvents.BLOCK_ENTITY_LOAD.register(this::onBlockEntityLoaded);
+
+        LOG.info(LOG_PREFIX + "Registering BLOCK_ENTITY_UNLOAD event");
+        ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.register(this::onBlockEntityUnloaded);
+
+        LOG.info(LOG_PREFIX + "Registering END_LEVEL_TICK event");
+        ServerTickEvents.END_LEVEL_TICK.register(QuicksortService.getInstance());
+    }
+
+    private int chestLoadCount = 0;
+    private int chestUnloadCount = 0;
+
+    private void onServerStarting(net.minecraft.server.MinecraftServer server) {
+        LOG.info(LOG_PREFIX + ">>> SERVER_STARTING: Resetting runtime state");
+        QuicksortService.getInstance().resetRuntimeState();
+        chestLoadCount = 0;
+        chestUnloadCount = 0;
+        LOG.info(LOG_PREFIX + "Runtime state reset complete");
+    }
+
+    private void onServerStarted(net.minecraft.server.MinecraftServer server) {
+        LOG.info(LOG_PREFIX + ">>> SERVER_STARTED: World loading complete. Chests loaded=" + chestLoadCount + ", Chests unloaded=" + chestUnloadCount);
+    }
+
+    private void onServerStopping(net.minecraft.server.MinecraftServer server) {
+        LOG.info(LOG_PREFIX + ">>> SERVER_STOPPING: Resetting runtime state");
+        QuicksortService.getInstance().resetRuntimeState();
+        LOG.info(LOG_PREFIX + "Runtime state reset complete");
+    }
+
+    private void onServerStopped(net.minecraft.server.MinecraftServer server) {
+        LOG.info(LOG_PREFIX + ">>> SERVER_STOPPED: Resetting runtime state");
+        QuicksortService.getInstance().resetRuntimeState();
+        LOG.info(LOG_PREFIX + "Runtime state reset complete");
+    }
+
+    void onBlockEntityLoaded(net.minecraft.world.level.block.entity.BlockEntity entity, net.minecraft.server.level.ServerLevel world) {
+        chestLoadCount++;
+        QuicksortService.getInstance().onBlockEntityLoaded(entity, world);
+    }
+
+    void onBlockEntityUnloaded(net.minecraft.world.level.block.entity.BlockEntity entity, net.minecraft.server.level.ServerLevel world) {
+        chestUnloadCount++;
+        QuicksortService.getInstance().onBlockEntityUnloaded(entity, world);
+    }
+
+    static void applyConfig(QuicksortConfig config, Logger logger) {
+        Configurator.setLevel(LOGGER_NAME, config.logLevel());
+        if (config.logLevel() != Level.INFO) logger.info(LOG_PREFIX + "LogLevel set to " + config.logLevel());
         QuicksortService.getInstance().init(config, logger);
-        ServerTickEvents.END_WORLD_TICK.register(QuicksortService.getInstance());
-        logger.info(LOG_PREFIX + "Initialized");
     }
 }

--- a/src/main/java/net/pcal/quicksort/QuicksortModMenuIntegration.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortModMenuIntegration.java
@@ -1,0 +1,277 @@
+package net.pcal.quicksort;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigCategory;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import me.shedaniel.clothconfig2.impl.builders.SubCategoryBuilder;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.pcal.quicksort.QuicksortConfig.AnimationMode;
+import net.pcal.quicksort.QuicksortConfig.QuicksortChestConfig;
+import net.pcal.quicksort.QuicksortConfig.TransferMode;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+import static net.pcal.quicksort.QuicksortService.LOGGER_NAME;
+
+public class QuicksortModMenuIntegration implements ModMenuApi {
+
+    private static final String[] LOG_LEVELS = {
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL",
+            "OFF"
+    };
+
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return QuicksortModMenuIntegration::createConfigScreen;
+    }
+
+    private static Screen createConfigScreen(Screen parent) {
+        final MutableConfig config = loadMutableConfig();
+        final QuicksortConfig defaultConfig = loadDefaultConfig();
+        final QuicksortChestConfig defaultChest = defaultConfig.chestConfigs().get(0);
+
+        final ConfigBuilder builder = ConfigBuilder.create()
+                .setParentScreen(parent)
+                .setTitle(Component.literal("Quicksort"));
+        final ConfigEntryBuilder entryBuilder = builder.entryBuilder();
+
+        final ConfigCategory general = builder.getOrCreateCategory(Component.literal("General"));
+        general.addEntry(entryBuilder.startSelector(Component.literal("Log level"), LOG_LEVELS, config.logLevel)
+                .setDefaultValue(defaultConfig.logLevel().toString())
+                .setNameProvider(Component::literal)
+                .setSaveConsumer(value -> config.logLevel = value.trim().toUpperCase(Locale.ROOT))
+                .build());
+
+        final ConfigCategory chests = builder.getOrCreateCategory(Component.literal("Quicksort Chests"));
+        for (MutableChestConfig chest : config.chests) {
+            chests.addEntry(createChestCategory(entryBuilder, chest, defaultChest).build());
+        }
+
+        builder.setSavingRunnable(() -> saveConfig(config));
+        return builder.build();
+    }
+
+    private static SubCategoryBuilder createChestCategory(
+            ConfigEntryBuilder entryBuilder,
+            MutableChestConfig chest,
+            QuicksortChestConfig defaultChest) {
+        final SubCategoryBuilder subCategory = entryBuilder.startSubCategory(Component.literal(chest.baseBlockId));
+        subCategory.setExpanded(false);
+        subCategory.add(entryBuilder.startStrField(Component.literal("Base block id"), chest.baseBlockId)
+                .setDefaultValue(defaultChest.baseBlockId().toString())
+                .setErrorSupplier(QuicksortModMenuIntegration::validateIdentifier)
+                .setSaveConsumer(value -> chest.baseBlockId = value.trim())
+                .build());
+        subCategory.add(entryBuilder.startIntField(Component.literal("Detection radius"), chest.range)
+                .setDefaultValue(defaultChest.range())
+                .setMin(1)
+                .setSaveConsumer(value -> chest.range = value)
+                .build());
+        subCategory.add(entryBuilder.startBooleanToggle(Component.literal("Check obstructions"), chest.checkObstructions)
+                .setDefaultValue(defaultChest.checkObstructions())
+                .setTooltip(Component.literal("When enabled, solid blocks between the quicksorter and target container will block transfers."))
+                .setSaveConsumer(value -> chest.checkObstructions = value)
+                .build());
+        subCategory.add(entryBuilder.startEnumSelector(Component.literal("Transfer mode"), TransferMode.class, chest.transferMode)
+                .setDefaultValue(defaultChest.transferMode())
+                .setEnumNameProvider(value -> Component.literal(value == TransferMode.STACKS ? "Stacks" : "Items"))
+                .setSaveConsumer(value -> chest.transferMode = value)
+                .build());
+        subCategory.add(entryBuilder.startIntField(Component.literal("Transfer amount"), chest.transferAmount)
+                .setDefaultValue(defaultChest.transferAmount())
+                .setMin(1)
+                .setTooltip(Component.literal("Per cooldown cycle. Items mode: amount per item type. Stacks mode: total stacks."))
+                .setSaveConsumer(value -> chest.transferAmount = value)
+                .build());
+        subCategory.add(entryBuilder.startBooleanToggle(Component.literal("Redstone activation"), chest.enableRedstoneActivation)
+                .setDefaultValue(defaultChest.enableRedstoneActivation())
+                .setTooltip(Component.literal("Starts sorting when the base block signal changes from off to on."))
+                .setSaveConsumer(value -> chest.enableRedstoneActivation = value)
+                .build());
+        subCategory.add(entryBuilder.startBooleanToggle(Component.literal("Continue while open"), chest.continueWhileOpen)
+                .setDefaultValue(defaultChest.continueWhileOpen())
+                .setTooltip(Component.literal("Keeps sorting while the quicksort chest is open."))
+                .setSaveConsumer(value -> chest.continueWhileOpen = value)
+                .build());
+        subCategory.add(entryBuilder.startIntField(Component.literal("Cooldown ticks"), chest.cooldownTicks)
+                .setDefaultValue(defaultChest.cooldownTicks())
+                .setMin(0)
+                .setSaveConsumer(value -> chest.cooldownTicks = value)
+                .build());
+        subCategory.add(entryBuilder.startIntField(Component.literal("Animation ticks"), chest.animationTicks)
+                .setDefaultValue(defaultChest.animationTicks())
+                .setMin(-1)
+                .setSaveConsumer(value -> chest.animationTicks = value)
+                .build());
+        subCategory.add(entryBuilder.startEnumSelector(Component.literal("Animation mode"), AnimationMode.class, chest.animationMode)
+                .setDefaultValue(defaultChest.animationMode())
+                .setEnumNameProvider(value -> Component.literal(value == AnimationMode.ENTITY ? "Entity" : "Particle"))
+                .setTooltip(Component.literal("Particle is the safest default. Entity uses temporary item entities for the old flying-item style."))
+                .setSaveConsumer(value -> chest.animationMode = value)
+                .build());
+        subCategory.add(entryBuilder.startFloatField(Component.literal("Sound volume"), chest.soundVolume)
+                .setDefaultValue(defaultChest.soundVolume())
+                .setMin(0.0F)
+                .setSaveConsumer(value -> chest.soundVolume = value)
+                .build());
+        subCategory.add(entryBuilder.startFloatField(Component.literal("Sound pitch"), chest.soundPitch)
+                .setDefaultValue(defaultChest.soundPitch())
+                .setMin(0.0F)
+                .setSaveConsumer(value -> chest.soundPitch = value)
+                .build());
+        subCategory.add(entryBuilder.startStrList(Component.literal("NBT/component match item ids"), chest.enchantmentMatchingIds)
+                .setDefaultValue(toStringList(defaultChest.enchantmentMatchingIds()))
+                .setCellErrorSupplier(QuicksortModMenuIntegration::validateIdentifier)
+                .setSaveConsumer(value -> chest.enchantmentMatchingIds = new ArrayList<>(value))
+                .build());
+        subCategory.add(entryBuilder.startStrList(Component.literal("Target container block ids"), chest.targetContainerIds)
+                .setDefaultValue(toStringList(defaultChest.targetContainerIds()))
+                .setCellErrorSupplier(QuicksortModMenuIntegration::validateIdentifier)
+                .setSaveConsumer(value -> chest.targetContainerIds = new ArrayList<>(value))
+                .build());
+        return subCategory;
+    }
+
+    private static MutableConfig loadMutableConfig() {
+        try {
+            return MutableConfig.from(QuicksortConfigManager.load());
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load Quicksort configuration", e);
+        }
+    }
+
+    private static QuicksortConfig loadDefaultConfig() {
+        try {
+            return QuicksortConfigManager.loadDefault();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load Quicksort default configuration", e);
+        }
+    }
+
+    private static void saveConfig(MutableConfig mutableConfig) {
+        final QuicksortConfig config = mutableConfig.toConfig();
+        try {
+            QuicksortConfigManager.save(config);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to save Quicksort configuration", e);
+        }
+        QuicksortInitializer.applyConfig(config, LogManager.getLogger(LOGGER_NAME));
+    }
+
+    private static Optional<Component> validateIdentifier(String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.of(Component.literal("Identifier is required."));
+        }
+        try {
+            Identifier.parse(value.trim());
+            return Optional.empty();
+        } catch (RuntimeException e) {
+            return Optional.of(Component.literal("Invalid identifier."));
+        }
+    }
+
+    private static List<String> toStringList(Set<Identifier> ids) {
+        return ids.stream().map(Identifier::toString).sorted().toList();
+    }
+
+    private static Set<Identifier> toIdentifierSet(List<String> ids) {
+        final Set<Identifier> out = new LinkedHashSet<>();
+        for (String id : ids) {
+            out.add(Identifier.parse(id.trim()));
+        }
+        return out;
+    }
+
+    private static final class MutableConfig {
+        private final List<MutableChestConfig> chests;
+        private String logLevel;
+
+        private MutableConfig(List<MutableChestConfig> chests, String logLevel) {
+            this.chests = chests;
+            this.logLevel = logLevel;
+        }
+
+        static MutableConfig from(QuicksortConfig config) {
+            return new MutableConfig(
+                    config.chestConfigs().stream().map(MutableChestConfig::from).toList(),
+                    config.logLevel().toString());
+        }
+
+        QuicksortConfig toConfig() {
+            final Level level = Level.getLevel(this.logLevel.trim().toUpperCase(Locale.ROOT));
+            return new QuicksortConfig(this.chests.stream().map(MutableChestConfig::toConfig).toList(), level);
+        }
+    }
+
+    private static final class MutableChestConfig {
+        private String baseBlockId;
+        private int range;
+        private int cooldownTicks;
+        private int animationTicks;
+        private AnimationMode animationMode;
+        private float soundVolume;
+        private float soundPitch;
+        private boolean checkObstructions;
+        private TransferMode transferMode;
+        private int transferAmount;
+        private boolean enableRedstoneActivation;
+        private boolean continueWhileOpen;
+        private List<String> enchantmentMatchingIds;
+        private List<String> targetContainerIds;
+
+        static MutableChestConfig from(QuicksortChestConfig config) {
+            final MutableChestConfig mutable = new MutableChestConfig();
+            mutable.baseBlockId = config.baseBlockId().toString();
+            mutable.range = config.range();
+            mutable.cooldownTicks = config.cooldownTicks();
+            mutable.animationTicks = config.animationTicks();
+            mutable.animationMode = config.animationMode();
+            mutable.soundVolume = config.soundVolume();
+            mutable.soundPitch = config.soundPitch();
+            mutable.checkObstructions = config.checkObstructions();
+            mutable.transferMode = config.transferMode();
+            mutable.transferAmount = config.transferAmount();
+            mutable.enableRedstoneActivation = config.enableRedstoneActivation();
+            mutable.continueWhileOpen = config.continueWhileOpen();
+            mutable.enchantmentMatchingIds = toStringList(config.enchantmentMatchingIds());
+            mutable.targetContainerIds = toStringList(config.targetContainerIds());
+            return mutable;
+        }
+
+        QuicksortChestConfig toConfig() {
+            return new QuicksortChestConfig(
+                    Identifier.parse(this.baseBlockId.trim()),
+                    this.range,
+                    this.cooldownTicks,
+                    this.animationTicks,
+                    this.animationMode,
+                    this.soundVolume,
+                    this.soundPitch,
+                    this.checkObstructions,
+                    this.transferMode,
+                    this.transferAmount,
+                    this.enableRedstoneActivation,
+                    this.continueWhileOpen,
+                    toIdentifierSet(this.enchantmentMatchingIds),
+                    toIdentifierSet(this.targetContainerIds)
+            );
+        }
+    }
+}

--- a/src/main/java/net/pcal/quicksort/QuicksortService.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortService.java
@@ -3,48 +3,54 @@ package net.pcal.quicksort;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import static java.util.Objects.requireNonNull;
+import java.util.Collections;
 import java.util.Random;
+import java.util.Set;
 
-import net.minecraft.core.component.DataComponentType;
-import net.minecraft.core.component.DataComponents;
-import net.minecraft.world.item.enchantment.ItemEnchantments;
 import org.apache.logging.log4j.Logger;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.particles.ItemParticleOption;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ChestBlock;
 import static net.minecraft.world.level.block.ChestBlock.getContainer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import net.minecraft.world.level.block.entity.HopperBlockEntity;
-import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.pcal.quicksort.QuicksortConfig.AnimationMode;
 import net.pcal.quicksort.QuicksortConfig.QuicksortChestConfig;
+import net.pcal.quicksort.QuicksortConfig.TransferMode;
 
 /**
  * Singleton that makes the quicksorter chests do their thing.
  */
-public class QuicksortService implements ServerTickEvents.EndWorldTick {
+public class QuicksortService implements ServerTickEvents.EndLevelTick {
 
     // ===================================================================================
     // Singleton
@@ -65,20 +71,51 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
     // Fields
 
     private final List<QuicksorterJob> jobs = new ArrayList<>();
+    private final Set<LevelChestPos> loadedChests = new HashSet<>();
+    private final Set<LevelChestPos> loadedContainers = new HashSet<>();
+    private final Set<LevelChestPos> openChests = new HashSet<>();
+    private final Map<LevelChestPos, Boolean> redstonePowered = new HashMap<>();
+    private final Map<LevelChestPos, Long> redstoneNextAttemptTick = new HashMap<>();
     private Map<Identifier, QuicksortChestConfig> config = null;
+    private boolean hasRedstoneActivation = false;
     private Logger logger = null;
 
     // ===================================================================================
     // Package methods
 
     void init(QuicksortConfig config, Logger logger) {
-        if (this.logger != null) throw new IllegalStateException();
-        this.logger = requireNonNull(logger);
-        if (this.config != null) throw new IllegalStateException();
-        this.config = new HashMap<>();
+        if (this.logger == null) this.logger = requireNonNull(logger);
+        updateConfig(config);
+    }
+
+    public void updateConfig(QuicksortConfig config) {
+        final Map<Identifier, QuicksortChestConfig> updatedConfig = new HashMap<>();
+        boolean redstoneActivation = false;
         for (final QuicksortChestConfig chest : config.chestConfigs()) {
-            this.config.put(chest.baseBlockId(), chest);
+            updatedConfig.put(chest.baseBlockId(), chest);
+            redstoneActivation |= chest.enableRedstoneActivation();
         }
+        this.config = updatedConfig;
+        this.hasRedstoneActivation = redstoneActivation;
+        if (!this.hasRedstoneActivation) {
+            this.redstonePowered.clear();
+            this.redstoneNextAttemptTick.clear();
+        }
+    }
+
+    public void resetRuntimeState() {
+        int oldJobs = this.jobs.size();
+        int oldChests = this.loadedChests.size();
+        for (final QuicksorterJob job : this.jobs) {
+            job.discardGhosts();
+        }
+        this.jobs.clear();
+        this.loadedChests.clear();
+        this.loadedContainers.clear();
+        this.openChests.clear();
+        this.redstonePowered.clear();
+        this.redstoneNextAttemptTick.clear();
+        this.logger.info(LOG_PREFIX + "Runtime state reset. Cleared " + oldJobs + " jobs, " + oldChests + " loaded chests");
     }
 
     // ===================================================================================
@@ -88,42 +125,84 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
      * When a chest is closed, start a new job.  Called from the mixin.
      */
     public void onChestClosed(ChestBlockEntity e) {
-        final ServerLevel world = requireNonNull((ServerLevel)e.getLevel());
-        final QuicksortChestConfig chestConfig = getChestConfigFor(world, e.getBlockPos());
-        if (chestConfig != null) {
-            final List<TargetContainer> visibles = getVisibleChestsNear(world, chestConfig, e, chestConfig.range());
-            if (!visibles.isEmpty()) {
-                final QuicksorterJob job = QuicksorterJob.create(world, chestConfig, e, visibles);
-                if (job != null) jobs.add(job);
-            }
+        final ServerLevel world;
+        try {
+            world = requireNonNull((ServerLevel)e.getLevel());
+        } catch (NullPointerException npe) {
+            this.logger.warn(LOG_PREFIX + "onChestClosed: Chest at " + e.getBlockPos() + " has no world attached!");
+            return;
+        }
+        final BlockPos chestPos = e.getBlockPos();
+        this.logger.info(LOG_PREFIX + "Chest closed at " + chestPos + " in " + world.dimension());
+        this.openChests.remove(LevelChestPos.of(world, chestPos));
+        startJob(world, e);
+    }
+
+    public void onChestOpened(ChestBlockEntity chestEntity) {
+        final ServerLevel world;
+        try {
+            world = requireNonNull((ServerLevel) chestEntity.getLevel());
+        } catch (NullPointerException npe) {
+            this.logger.warn(LOG_PREFIX + "onChestOpened: Chest at " + chestEntity.getBlockPos() + " has no world attached!");
+            return;
+        }
+        final BlockPos chestPos = chestEntity.getBlockPos();
+        this.logger.info(LOG_PREFIX + "Chest opened at " + chestPos + " in " + world.dimension());
+        this.openChests.add(LevelChestPos.of(world, chestPos));
+        final QuicksortChestConfig chestConfig = getChestConfigFor(world, chestPos);
+        if (chestConfig != null && chestConfig.continueWhileOpen()) {
+            this.logger.debug(LOG_PREFIX + "Chest at " + chestPos + " configured to continue while open");
+            return;
+        }
+        stopJobsAt(world, chestPos);
+    }
+
+    public void onBlockEntityLoaded(BlockEntity entity, ServerLevel world) {
+        if (entity instanceof Container) {
+            this.loadedContainers.add(LevelChestPos.of(world, entity.getBlockPos()));
+        }
+        if (entity instanceof ChestBlockEntity chestEntity) {
+            final BlockPos chestPos = chestEntity.getBlockPos();
+            final LevelChestPos key = LevelChestPos.of(world, chestPos);
+            this.loadedChests.add(key);
+            this.redstonePowered.remove(key);
+            this.redstoneNextAttemptTick.remove(key);
+            this.logger.debug(LOG_PREFIX + "Chest loaded at " + chestPos + " in " + world.dimension() + " (total tracked: " + this.loadedChests.size() + ")");
         }
     }
 
-    /**
-     * When a chest is opened, we stop any jobs running on it (there really should be at most one).
-     * Called from the mixin.
-     */
-    public void onChestOpened(ChestBlockEntity chestEntity) {
-        for (final QuicksorterJob job : this.jobs) {
-            if (job.quicksorterPos.equals(chestEntity.getBlockPos())) job.stop();
+    public void onBlockEntityUnloaded(BlockEntity entity, ServerLevel world) {
+        if (entity instanceof Container) {
+            this.loadedContainers.remove(LevelChestPos.of(world, entity.getBlockPos()));
+        }
+        if (entity instanceof ChestBlockEntity chestEntity) {
+            final BlockPos chestPos = chestEntity.getBlockPos();
+            final LevelChestPos key = LevelChestPos.of(world, chestPos);
+            this.loadedChests.remove(key);
+            this.openChests.remove(key);
+            this.redstonePowered.remove(key);
+            this.redstoneNextAttemptTick.remove(key);
+            this.logger.debug(LOG_PREFIX + "Chest unloaded at " + chestPos + " in " + world.dimension() + " (total tracked: " + this.loadedChests.size() + ")");
         }
     }
 
     // ===================================================================================
-    // EndWorldTick implementation
+    // EndLevelTick implementation
 
     @Override
     public void onEndTick(ServerLevel world) {
+        if (this.hasRedstoneActivation) processRedstoneActivations(world);
         if (this.jobs.isEmpty()) return;
+        this.logger.debug(LOG_PREFIX + "onEndTick: Processing " + this.jobs.size() + " active jobs in " + world.dimension());
         Iterator<QuicksorterJob> i = this.jobs.iterator();
         while (i.hasNext()) {
             final QuicksorterJob job = i.next();
             if (job.isDone()) {
-                this.logger.debug(LOG_PREFIX + " job completed for chest at " + job.quicksorterPos);
+                this.logger.info(LOG_PREFIX + "Job completed for chest at " + job.quicksorterPos + " in " + world.dimension());
                 i.remove();
             } else {
-                if (world.dimensionType().equals(job.dimension)) {
-                    job.tick(world);
+                if (world.dimension().equals(job.dimension)) {
+                    job.tick(world, this.openChests.contains(LevelChestPos.of(world, job.quicksorterPos)));
                 }
             }
         }
@@ -138,9 +217,132 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
         return this.config.get(baseBlockId);
     }
 
+    private boolean startJob(ServerLevel world, ChestBlockEntity chestEntity) {
+        final BlockPos chestPos = chestEntity.getBlockPos();
+        final QuicksortChestConfig chestConfig = getChestConfigFor(world, chestPos);
+        if (chestConfig == null) {
+            this.logger.debug(LOG_PREFIX + "Skipping sort job at " + chestPos + ": no config for base block");
+            return false;
+        }
+        if (!chestConfig.continueWhileOpen() && this.openChests.contains(LevelChestPos.of(world, chestPos))) {
+            this.logger.debug(LOG_PREFIX + "Skipping sort job at " + chestPos + ": chest is open");
+            return false;
+        }
+        if (hasActiveJob(world, chestPos)) {
+            this.logger.debug(LOG_PREFIX + "Skipping sort job at " + chestPos + ": active job already exists");
+            return false;
+        }
+        final Container sourceInventory = SlotJob.getInventoryFor(world, chestPos);
+        if (sourceInventory == null || isEmpty(sourceInventory)) {
+            this.logger.debug(LOG_PREFIX + "Skipping sort job at " + chestPos + ": source chest is empty or unavailable");
+            return false;
+        }
+        this.logger.info(LOG_PREFIX + "Starting sort job for chest at " + chestPos + " with range=" + chestConfig.range() + ", checkObstructions=" + chestConfig.checkObstructions());
+        final List<TargetContainer> visibles = getVisibleChestsNear(world, chestConfig, chestEntity, chestConfig.range());
+        if (!visibles.isEmpty()) {
+            final QuicksorterJob job = QuicksorterJob.create(world, chestConfig, chestEntity, visibles);
+            if (job != null) {
+                jobs.add(job);
+                this.logger.info(LOG_PREFIX + "Sort job created for chest at " + chestPos + ": " + visibles.size() + " targets, " + job.slotJobs.size() + " slot jobs");
+                return true;
+            } else {
+                this.logger.debug(LOG_PREFIX + "Sort job not created (no valid slots) for chest at " + chestPos);
+            }
+        } else {
+            this.logger.info(LOG_PREFIX + "Sort job skipped for chest at " + chestPos + ": no target containers found");
+        }
+        return false;
+    }
+
+    private boolean hasActiveJob(ServerLevel world, BlockPos chestPos) {
+        for (final QuicksorterJob job : this.jobs) {
+            if (job.isTransferActive() && world.dimension().equals(job.dimension) && job.quicksorterPos.equals(chestPos)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void stopJobsAt(ServerLevel world, BlockPos chestPos) {
+        for (final QuicksorterJob job : this.jobs) {
+            if (world.dimension().equals(job.dimension) && job.quicksorterPos.equals(chestPos)) job.stop();
+        }
+    }
+
+    private void processRedstoneActivations(ServerLevel world) {
+        int chestsChecked = 0;
+        int jobsStarted = 0;
+        final long currentTick = world.getServer().getTickCount();
+        final Iterator<LevelChestPos> i = this.loadedChests.iterator();
+        while (i.hasNext()) {
+            final LevelChestPos key = i.next();
+            if (!world.dimension().equals(key.dimension())) continue;
+            chestsChecked++;
+            final BlockEntity entity = world.getBlockEntity(key.pos());
+            if (!(entity instanceof ChestBlockEntity chestEntity)) {
+                i.remove();
+                this.openChests.remove(key);
+                this.redstonePowered.remove(key);
+                this.redstoneNextAttemptTick.remove(key);
+                continue;
+            }
+            final QuicksortChestConfig chestConfig = getChestConfigFor(world, key.pos());
+            if (chestConfig == null || !chestConfig.enableRedstoneActivation()) {
+                this.redstonePowered.remove(key);
+                this.redstoneNextAttemptTick.remove(key);
+                continue;
+            }
+            final boolean powered = isBasePowered(world, key.pos());
+            final Boolean previousPowered = this.redstonePowered.put(key, powered);
+            if (previousPowered == null) {
+                if (powered) this.redstoneNextAttemptTick.put(key, Long.MAX_VALUE);
+                continue;
+            }
+            final boolean wasPowered = previousPowered;
+            this.redstonePowered.put(key, powered);
+            if (!powered) {
+                this.redstoneNextAttemptTick.remove(key);
+                continue;
+            }
+            if (hasActiveJob(world, key.pos())) continue;
+            final long nextAttemptTick = this.redstoneNextAttemptTick.getOrDefault(key, 0L);
+            if (!wasPowered || currentTick >= nextAttemptTick) {
+                this.logger.info(LOG_PREFIX + "Redstone activation detected for chest at " + key.pos());
+                if (startJob(world, chestEntity)) jobsStarted++;
+                this.redstoneNextAttemptTick.put(key, currentTick + Math.max(20, chestConfig.cooldownTicks()));
+            }
+        }
+        if (chestsChecked > 0) {
+            this.logger.debug(LOG_PREFIX + "Redstone scan: checked=" + chestsChecked + ", jobsStarted=" + jobsStarted + " in " + world.dimension());
+        }
+    }
+
+    private static boolean isBasePowered(ServerLevel world, BlockPos chestPos) {
+        return world.hasNeighborSignal(chestPos.below());
+    }
+
+    private static boolean isEmpty(Container inventory) {
+        for (int slot = 0; slot < inventory.getContainerSize(); slot++) {
+            if (!inventory.getItem(slot).isEmpty()) return false;
+        }
+        return true;
+    }
+
+    private static boolean isPathClear(ServerLevel world, Vec3 origin, Vec3 target) {
+        final BlockHitResult result = world.clip(new ClipContext(origin, target,
+                ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, CollisionContext.empty()));
+        return result.getType() == HitResult.Type.MISS || result.getLocation().distanceToSqr(target) < 1.0E-6D;
+    }
+
     @FunctionalInterface
     interface GhostCreator {
         void createGhost(ServerLevel world, Item item, TargetContainer targetContainer);
+    }
+
+    private record LevelChestPos(ResourceKey<Level> dimension, BlockPos pos) {
+        static LevelChestPos of(ServerLevel world, BlockPos pos) {
+            return new LevelChestPos(world.dimension(), pos.immutable());
+        }
     }
 
     /**
@@ -150,25 +352,29 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
     private static class QuicksorterJob {
         private final BlockPos quicksorterPos;
         private final QuicksortChestConfig quicksorterConfig;
+        private final List<TargetContainer> visibleTargets;
         private final List<GhostItemEntity> ghostItems = new ArrayList<>();
         private final List<SlotJob> slotJobs;
-        private final DimensionType dimension;
+        private final ResourceKey<Level> dimension;
         private boolean isTransferComplete = false;
         int tick = 0;
 
         static QuicksorterJob create(ServerLevel world, QuicksortChestConfig chestConfig, ChestBlockEntity originChest, List<TargetContainer> visibleTargets) {
+            final Container originInventory = SlotJob.getInventoryFor(world, originChest.getBlockPos());
+            if (originInventory == null) return null;
             final List<SlotJob> slotJobs = new ArrayList<>();
-            for (int slot = 0; slot < originChest.getContainerSize(); slot++) {
-                final SlotJob slotJob = SlotJob.create(world, chestConfig, originChest, slot, visibleTargets);
+            for (int slot = 0; slot < originInventory.getContainerSize(); slot++) {
+                final SlotJob slotJob = SlotJob.create(world, chestConfig, originInventory, originChest.getBlockPos(), slot, visibleTargets);
                 if (slotJob != null) slotJobs.add(slotJob);
             }
-            return slotJobs.isEmpty() ? null : new QuicksorterJob(chestConfig, world.dimensionType(), originChest.getBlockPos(), slotJobs);
+            return slotJobs.isEmpty() ? null : new QuicksorterJob(chestConfig, world.dimension(), originChest.getBlockPos(), visibleTargets, slotJobs);
         }
 
-        QuicksorterJob(QuicksortChestConfig chestConfig, DimensionType dimension, BlockPos quicksorterPos, List<SlotJob> slotJobs) {
+        QuicksorterJob(QuicksortChestConfig chestConfig, ResourceKey<Level> dimension, BlockPos quicksorterPos, List<TargetContainer> visibleTargets, List<SlotJob> slotJobs) {
             this.quicksorterConfig = requireNonNull(chestConfig);
             this.dimension = requireNonNull(dimension);
             this.quicksorterPos = requireNonNull(quicksorterPos);
+            this.visibleTargets = requireNonNull(visibleTargets);
             this.slotJobs = requireNonNull(slotJobs);
         }
 
@@ -176,64 +382,215 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
             return this.isTransferComplete && this.ghostItems.isEmpty();
         }
 
-        public void tick(ServerLevel world) {
-            final Iterator<GhostItemEntity> g = this.ghostItems.iterator();
-            while (g.hasNext()) {
-                final GhostItemEntity e = g.next();
-                if (e.getAge() > this.quicksorterConfig.animationTicks()) {
-                    e.makeFakeItem();
-                    g.remove();
-                }
-            }
+        public boolean isTransferActive() {
+            return !this.isTransferComplete;
+        }
+
+        public void tick(ServerLevel world, boolean quicksorterChestOpen) {
+            cleanupGhosts();
             if (!this.isTransferComplete) {
                 if (tick++ > this.quicksorterConfig.cooldownTicks()) {
                     tick = 0;
-                    if (!doOneTransfer(world)) this.isTransferComplete = true;
+                    refreshSlotJobs(world);
+                    if (!doTransferOperation(world)) {
+                        refreshSlotJobs(world);
+                        if (this.slotJobs.isEmpty() && !(this.quicksorterConfig.continueWhileOpen() && quicksorterChestOpen)) {
+                            this.isTransferComplete = true;
+                        }
+                    }
                 }
+            }
+            cleanupGhosts();
+        }
+
+        private void cleanupGhosts() {
+            final Iterator<GhostItemEntity> i = this.ghostItems.iterator();
+            while (i.hasNext()) {
+                if (i.next().isRemoved()) i.remove();
             }
         }
 
-        private boolean doOneTransfer(final ServerLevel world) {
+        private void refreshSlotJobs(ServerLevel world) {
+            final Container originInventory = SlotJob.getInventoryFor(world, this.quicksorterPos);
+            if (originInventory == null) {
+                this.slotJobs.clear();
+                return;
+            }
+            final Set<Integer> activeSlots = new HashSet<>();
+            for (final SlotJob slotJob : this.slotJobs) {
+                activeSlots.add(slotJob.slot());
+            }
+            for (int slot = 0; slot < originInventory.getContainerSize(); slot++) {
+                if (activeSlots.contains(slot)) continue;
+                final SlotJob slotJob = SlotJob.create(world, this.quicksorterConfig, originInventory, this.quicksorterPos, slot, this.visibleTargets);
+                if (slotJob != null) this.slotJobs.add(slotJob);
+            }
+        }
+
+        private boolean doTransferOperation(final ServerLevel world) {
             requireNonNull(world);
-            SlotJob slotJob;
-            do {
-                final int jobIndex = new Random().nextInt(this.slotJobs.size());
-                slotJob = this.slotJobs.get(jobIndex);
-                if (!slotJob.doOneTransfer(world, this::createGhost)) {
-                    this.slotJobs.remove(jobIndex);
+            if (this.quicksorterConfig.transferMode() == TransferMode.STACKS) {
+                return doStackTransferOperation(world);
+            }
+            return doItemTransferOperation(world);
+        }
+
+        private boolean doStackTransferOperation(final ServerLevel world) {
+            boolean movedAny = false;
+            boolean blockedAny = false;
+            int stacksTransferred = 0;
+            final List<SlotJob> candidates = new ArrayList<>(this.slotJobs);
+            Collections.shuffle(candidates, new Random());
+            for (final SlotJob slotJob : candidates) {
+                if (stacksTransferred >= this.quicksorterConfig.transferAmount()) break;
+                if (!this.slotJobs.contains(slotJob)) continue;
+                final TransferResult result = slotJob.doOneStackTransfer(world, this::createGhost);
+                if (result.blocked()) {
+                    blockedAny = true;
+                } else if (!result.success()) {
+                    this.slotJobs.remove(slotJob);
                 } else {
+                    stacksTransferred++;
+                    movedAny = true;
+                }
+            }
+            return movedAny || blockedAny;
+        }
+
+        private boolean doItemTransferOperation(final ServerLevel world) {
+            final Map<Item, Integer> itemsTransferred = new HashMap<>();
+            boolean movedAny = false;
+            boolean blockedAny = false;
+            boolean movedThisPass;
+            do {
+                movedThisPass = false;
+                final Iterator<SlotJob> i = this.slotJobs.iterator();
+                while (i.hasNext()) {
+                    final SlotJob slotJob = i.next();
+                    final Item item = slotJob.getCurrentItem(world);
+                    if (item == null) {
+                        i.remove();
+                        continue;
+                    }
+                    if (itemsTransferred.getOrDefault(item, 0) >= this.quicksorterConfig.transferAmount()) {
+                        continue;
+                    }
+                    final TransferResult result = slotJob.doOneItemTransfer(world, this::createGhost);
+                    if (result.blocked()) {
+                        blockedAny = true;
+                    } else if (!result.success()) {
+                        i.remove();
+                    } else {
+                        itemsTransferred.merge(result.item(), result.movedCount(), Integer::sum);
+                        movedAny = true;
+                        movedThisPass = true;
+                    }
+                }
+            } while (movedThisPass && hasRemainingItemBudget(world, itemsTransferred));
+            return movedAny || blockedAny;
+        }
+
+        private boolean hasRemainingItemBudget(final ServerLevel world, final Map<Item, Integer> itemsTransferred) {
+            for (SlotJob slotJob : this.slotJobs) {
+                final Item item = slotJob.getCurrentItem(world);
+                if (item != null && itemsTransferred.getOrDefault(item, 0) < this.quicksorterConfig.transferAmount()) {
                     return true;
                 }
-            } while (!slotJobs.isEmpty());
+            }
             return false;
         }
 
         private void createGhost(ServerLevel world, Item item, TargetContainer targetChest) {
-            world.playSound(
+            if (this.quicksorterConfig.soundVolume() > 0.0F) {
+                world.playSound(
                     null,                            // Player - if non-null, will play sound for every nearby player *except* the specified player
                     this.quicksorterPos,             // The position of where the sound will come from
-                    SoundEvents.UI_TOAST_OUT,        // The sound that will play, in this case, the sound the anvil plays when it lands.
+                        SoundEvents.ITEM_PICKUP,
                     SoundSource.BLOCKS,            // This determines which of the volume sliders affect this sound
                     quicksorterConfig.soundVolume(), // .75f
                     quicksorterConfig.soundPitch()   // 2.0f // Pitch multiplier, 1 is normal, 0.5 is half pitch, etc
-            );
-            ItemStack ghostStack = new ItemStack(item, 1);
-            GhostItemEntity itemEntity = new GhostItemEntity(world,
-                    targetChest.originItemPos.x(), targetChest.originItemPos.y(), targetChest.originItemPos.z(), ghostStack);
-            this.ghostItems.add(itemEntity);
+                );
+            }
+            if (this.quicksorterConfig.animationTicks() <= 0) return;
+            if (this.quicksorterConfig.animationMode() == AnimationMode.ENTITY) {
+                createEntityGhost(world, item, targetChest);
+            } else {
+                createParticleGhost(world, item, targetChest);
+            }
+        }
+
+        private void createParticleGhost(ServerLevel world, Item item, TargetContainer targetChest) {
+            world.sendParticles(
+                    new ItemParticleOption(ParticleTypes.ITEM, item),
+                    targetChest.originItemPos.x(),
+                    targetChest.originItemPos.y(),
+                    targetChest.originItemPos.z(),
+                    0,
+                    targetChest.itemVelocity.x(),
+                    targetChest.itemVelocity.y(),
+                    targetChest.itemVelocity.z(),
+                    1.0D);
+        }
+
+        private void createEntityGhost(ServerLevel world, Item item, TargetContainer targetChest) {
+            final GhostItemEntity itemEntity = new GhostItemEntity(
+                    world,
+                    targetChest.originItemPos.x(),
+                    targetChest.originItemPos.y(),
+                    targetChest.originItemPos.z(),
+                    new ItemStack(item, 1),
+                    this.quicksorterConfig.animationTicks());
             itemEntity.setNoGravity(true);
             itemEntity.setOnGround(false);
             itemEntity.setInvulnerable(true);
             itemEntity.setDeltaMovement(targetChest.itemVelocity);
-            world.addFreshEntity(itemEntity);
+            if (world.addFreshEntity(itemEntity)) {
+                this.ghostItems.add(itemEntity);
+            }
         }
 
         public void stop() {
             this.isTransferComplete = true;
             this.slotJobs.clear();
+            discardGhosts();
+        }
+
+        public void discardGhosts() {
+            for (final GhostItemEntity ghost : this.ghostItems) {
+                ghost.discard();
+            }
+            this.ghostItems.clear();
         }
     }
 
+    private enum TransferStatus {
+        MOVED,
+        BLOCKED,
+        DONE
+    }
+
+    private record TransferResult(TransferStatus status, Item item, int movedCount) {
+
+        boolean success() {
+            return this.status == TransferStatus.MOVED;
+        }
+
+        boolean blocked() {
+            return this.status == TransferStatus.BLOCKED;
+        }
+
+        static TransferResult none() {
+            return new TransferResult(TransferStatus.DONE, null, 0);
+        }
+
+        static TransferResult blockedResult() {
+            return new TransferResult(TransferStatus.BLOCKED, null, 0);
+        }
+
+        static TransferResult moved(Item item, int movedCount) {
+            return new TransferResult(TransferStatus.MOVED, requireNonNull(item), movedCount);
+        }
+    }
 
     /**
      * Encapsulates the work to move items out of a specific slot in the quicksorter chest.
@@ -242,11 +599,12 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
         private final QuicksortChestConfig quicksorterConfig;
         private final BlockPos quicksorterPos;
         private final int slot;
+        private final ItemStack sourceStack;
         private final List<TargetContainer> targets;
 
 
-        static SlotJob create(ServerLevel world, QuicksortChestConfig chestConfig, RandomizableContainerBlockEntity originChest, int slot, List<TargetContainer> allVisibleContainers) {
-            final ItemStack originStack = originChest.getItem(slot);
+        static SlotJob create(ServerLevel world, QuicksortChestConfig chestConfig, Container originInventory, BlockPos originPos, int slot, List<TargetContainer> allVisibleContainers) {
+            final ItemStack originStack = originInventory.getItem(slot);
             if (originStack == null || originStack.isEmpty()) return null;
             final List<TargetContainer> targetContainers = new ArrayList<>();
             for (TargetContainer visibleContainer : allVisibleContainers) {
@@ -256,55 +614,129 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
                     targetContainers.add(visibleContainer);
                 }
             }
-            return targetContainers.isEmpty() ? null : new SlotJob(chestConfig, originChest.getBlockPos(), slot, targetContainers);
+            return targetContainers.isEmpty() ? null : new SlotJob(chestConfig, originPos, slot, originStack.copy(), targetContainers);
         }
 
-        private SlotJob(QuicksortChestConfig chestConfig, BlockPos quicksorterPos, int slot, List<TargetContainer> candidateChests) {
+        private SlotJob(QuicksortChestConfig chestConfig, BlockPos quicksorterPos, int slot, ItemStack sourceStack, List<TargetContainer> candidateChests) {
             this.quicksorterConfig = requireNonNull(chestConfig);
             this.quicksorterPos = requireNonNull(quicksorterPos);
+            this.sourceStack = requireNonNull(sourceStack);
             this.targets = requireNonNull(candidateChests);
             this.slot = slot;
         }
 
+        int slot() {
+            return this.slot;
+        }
+
+        Item getCurrentItem(final ServerLevel world) {
+            final Container quicksorterInventory = getInventoryFor(world, this.quicksorterPos);
+            if (quicksorterInventory == null) return null;
+            final ItemStack originStack = quicksorterInventory.getItem(this.slot);
+            return isCurrentStackValid(originStack) ? originStack.getItem() : null;
+        }
+
         /**
-         * Attempt to transfer one item, creating an appropriate GhostEntity.  Return true if successful; if not,
-         * false is returned with the expectation that the SlotJob will then be terminated.
+         * Attempt to transfer one item. Blocked targets are retried on a later cooldown instead of terminating
+         * the slot job, because the obstruction may be temporary.
          */
-        boolean doOneTransfer(final ServerLevel world, final GhostCreator gc) {
+        TransferResult doOneItemTransfer(final ServerLevel world, final GhostCreator gc) {
             requireNonNull(world, "null gc");
             final Container quicksorterInventory = getInventoryFor(world, this.quicksorterPos);
             if (quicksorterInventory == null) {
-                return false; // quicksorter presumably was destroyed
+                return TransferResult.none(); // quicksorter presumably was destroyed
             }
             final ItemStack originStack = quicksorterInventory.getItem(this.slot);
-            if (originStack.isEmpty()) return false;
-            while (!this.targets.isEmpty()) {
+            if (!isCurrentStackValid(originStack)) return TransferResult.none();
+            boolean blockedAny = false;
+            final List<TargetContainer> candidates = new ArrayList<>(this.targets);
+            Collections.shuffle(candidates, new Random());
+            for (final TargetContainer candidate : candidates) {
+                if (!this.targets.contains(candidate)) continue;
                 final ItemStack copy = originStack.copy();
                 final Item ghostItem = copy.getItem();
                 copy.setCount(1);
-                final int candidateIndex = new Random().nextInt(this.targets.size());
-                final TargetContainer candidate = this.targets.get(candidateIndex);
                 final Container targetInventory = getInventoryFor(world, candidate.blockPos());
                 if (targetInventory == null) {
-                    this.targets.remove(candidateIndex); // target has probably been destroyed
+                    this.targets.remove(candidate); // target has probably been destroyed
+                    continue;
+                }
+                if (!isCandidatePathClear(world, candidate)) {
+                    blockedAny = true;
                     continue;
                 }
                 final ItemStack itemStack2 = HopperBlockEntity.addItem((Container) null, targetInventory, copy, (Direction) null);
                 if (!itemStack2.isEmpty()) {
-                    this.targets.remove(candidateIndex); // target is full
+                    this.targets.remove(candidate); // target is full
                     continue;
                 }
                 // ok, we successfully transferred an item.  the minecraft code doesn't do the bookkeeping
                 // for us on the origin chest, so:
                 originStack.shrink(1);
                 quicksorterInventory.setChanged();
-                if (this.quicksorterConfig.animationTicks() > 0) {
-                    // create some animation (after the fact but whatever)
-                    gc.createGhost(world, ghostItem, candidate);
-                }
-                return true;
+                gc.createGhost(world, ghostItem, candidate);
+                return TransferResult.moved(ghostItem, 1);
             }
-            return false;
+            return blockedAny ? TransferResult.blockedResult() : TransferResult.none();
+        }
+
+        /**
+         * Attempt to transfer one source stack. If the first target only has partial space, keep trying other targets
+         * as part of the same stack transfer.
+         */
+        TransferResult doOneStackTransfer(final ServerLevel world, final GhostCreator gc) {
+            requireNonNull(world, "null gc");
+            final Container quicksorterInventory = getInventoryFor(world, this.quicksorterPos);
+            if (quicksorterInventory == null) {
+                return TransferResult.none(); // quicksorter presumably was destroyed
+            }
+            final ItemStack originStack = quicksorterInventory.getItem(this.slot);
+            if (!isCurrentStackValid(originStack)) return TransferResult.none();
+            final Item movedItem = originStack.getItem();
+            ItemStack remaining = originStack.copy();
+            int movedCount = 0;
+            boolean blockedAny = false;
+            final List<TargetContainer> candidates = new ArrayList<>(this.targets);
+            Collections.shuffle(candidates, new Random());
+            for (final TargetContainer candidate : candidates) {
+                if (remaining.isEmpty()) break;
+                if (!this.targets.contains(candidate)) continue;
+                final Container targetInventory = getInventoryFor(world, candidate.blockPos());
+                if (targetInventory == null) {
+                    this.targets.remove(candidate); // target has probably been destroyed
+                    continue;
+                }
+                if (!isCandidatePathClear(world, candidate)) {
+                    blockedAny = true;
+                    continue;
+                }
+                final int before = remaining.getCount();
+                final ItemStack notMoved = HopperBlockEntity.addItem((Container) null, targetInventory, remaining.copy(), (Direction) null);
+                final int movedToTarget = before - notMoved.getCount();
+                if (movedToTarget <= 0) {
+                    this.targets.remove(candidate); // target is full
+                    continue;
+                }
+                movedCount += movedToTarget;
+                remaining = notMoved;
+                gc.createGhost(world, movedItem, candidate);
+                if (!remaining.isEmpty()) {
+                    this.targets.remove(candidate); // no more space in this target for the rest of this stack
+                }
+            }
+            if (movedCount <= 0) return blockedAny ? TransferResult.blockedResult() : TransferResult.none();
+            originStack.shrink(movedCount);
+            quicksorterInventory.setChanged();
+            return TransferResult.moved(movedItem, movedCount);
+        }
+
+        private boolean isCandidatePathClear(ServerLevel world, TargetContainer candidate) {
+            return !this.quicksorterConfig.checkObstructions() ||
+                    QuicksortService.isPathClear(world, candidate.originItemPos(), candidate.targetItemPos());
+        }
+
+        private boolean isCurrentStackValid(ItemStack stack) {
+            return !stack.isEmpty() && isMatch(this.sourceStack, stack, this.quicksorterConfig.enchantmentMatchingIds());
         }
 
         /**
@@ -396,39 +828,63 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
     }
 
     private List<TargetContainer> getVisibleChestsNear(ServerLevel world, QuicksortChestConfig chestConfig,ChestBlockEntity originChest, int distance) {
-        final GhostItemEntity itemEntity = new GhostItemEntity(world, 0, 0, 0, new ItemStack(Blocks.COBBLESTONE));
+        final long startTime = System.currentTimeMillis();
+        final BlockPos originPos = originChest.getBlockPos();
+        this.logger.info(LOG_PREFIX + "[PERF] Scanning for targets: origin=" + originPos + ", range=" + distance + ", checkObstructions=" + chestConfig.checkObstructions());
+
         List<TargetContainer> out = new ArrayList<>();
-        for (int d = originChest.getBlockPos().getX() - distance; d <= originChest.getBlockPos().getX() + distance; d++) {
-            for (int e = originChest.getBlockPos().getY() - distance; e <= originChest.getBlockPos().getY() + distance; e++) {
-                for (int f = originChest.getBlockPos().getZ() - distance; f <= originChest.getBlockPos().getZ() + distance; f++) {
-                    if (d == originChest.getBlockPos().getX() && e == originChest.getBlockPos().getY() && f == originChest.getBlockPos().getZ())
-                        continue;
-                    final BlockPos targetPos = new BlockPos(d, e, f);
-                    final BlockState targetState = world.getBlockState(new BlockPos(d, e, f));
-                    final Block targetBlock = targetState.getBlock();
-                    final Identifier targetId = BuiltInRegistries.BLOCK.getKey(targetBlock);
-                    if (!chestConfig.targetContainerIds().contains(targetId)) continue;
-                    if (targetBlock instanceof ChestBlock && getChestConfigFor(world, targetPos) != null) {
-                        continue; // skip other sorting chests
-                    }
+        int containersScanned = 0;
+        int unloadedContainers = 0;
+        final List<LevelChestPos> candidates = this.loadedContainers.stream()
+                .filter(key -> world.dimension().equals(key.dimension()))
+                .sorted((left, right) -> left.pos().compareTo(right.pos()))
+                .toList();
+        for (final LevelChestPos candidate : candidates) {
+            final BlockPos targetPos = candidate.pos();
+            if (targetPos.equals(originPos)) continue;
+            if (!isWithinCubeRange(originPos, targetPos, distance)) continue;
+            containersScanned++;
 
-                    final Vec3 origin = getTransferPoint(originChest.getBlockPos(), targetPos);
-                    final Vec3 target = getTransferPoint(targetPos, originChest.getBlockPos());
-
-                    BlockHitResult result = world.clip(new ClipContext(origin, target,
-                            ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, itemEntity));
-                    if (result.getLocation().equals(target)) {
-                        this.logger.debug(() -> LOG_PREFIX + " visible chest found at " + result.getBlockPos() + " " + targetPos);
-                        Vec3 itemVelocity = new Vec3(
-                                (target.x() - origin.x()) / chestConfig.animationTicks(),
-                                (target.y() - origin.y()) / chestConfig.animationTicks(),
-                                (target.z() - origin.z()) / chestConfig.animationTicks());
-                        out.add(new TargetContainer(targetPos, origin, target, itemVelocity));
-                    }
-                }
+            if (!world.hasChunkAt(targetPos)) {
+                unloadedContainers++;
+                this.logger.debug(LOG_PREFIX + "[PERF] Skipping unloaded container at " + targetPos);
+                continue;
             }
+
+            final BlockState targetState = world.getBlockState(targetPos);
+            final Block targetBlock = targetState.getBlock();
+            final Identifier targetId = BuiltInRegistries.BLOCK.getKey(targetBlock);
+            if (!chestConfig.targetContainerIds().contains(targetId)) continue;
+            if (targetBlock instanceof ChestBlock && getChestConfigFor(world, targetPos) != null) {
+                continue; // skip other sorting chests
+            }
+
+            final Vec3 origin = getTransferPoint(originChest.getBlockPos(), targetPos);
+            final Vec3 target = getTransferPoint(targetPos, originChest.getBlockPos());
+
+            if (chestConfig.checkObstructions() && !isPathClear(world, origin, target)) continue;
+            this.logger.debug(LOG_PREFIX + "Target container found at " + targetPos);
+            Vec3 itemVelocity = chestConfig.animationTicks() > 0 ?
+                    new Vec3(
+                            (target.x() - origin.x()) / chestConfig.animationTicks(),
+                            (target.y() - origin.y()) / chestConfig.animationTicks(),
+                            (target.z() - origin.z()) / chestConfig.animationTicks()) :
+                    Vec3.ZERO;
+            out.add(new TargetContainer(targetPos, origin, target, itemVelocity));
+        }
+
+        final long elapsed = System.currentTimeMillis() - startTime;
+        this.logger.info(LOG_PREFIX + "[PERF] getVisibleChestsNear: completed in " + elapsed + "ms, containersScanned=" + containersScanned + ", unloadedContainers=" + unloadedContainers + ", targetsFound=" + out.size());
+        if (elapsed > 1000) {
+            this.logger.warn(LOG_PREFIX + "[PERF] Scan took " + elapsed + "ms! Consider reducing range (currently " + distance + ")");
         }
         return out;
+    }
+
+    private static boolean isWithinCubeRange(BlockPos origin, BlockPos target, int distance) {
+        return Math.abs(target.getX() - origin.getX()) <= distance &&
+                Math.abs(target.getY() - origin.getY()) <= distance &&
+                Math.abs(target.getZ() - origin.getZ()) <= distance;
     }
 
     private static Vec3 getTransferPoint(BlockPos origin, BlockPos target) {

--- a/src/main/java/net/pcal/quicksort/mixins/QuicksortChestMixin.java
+++ b/src/main/java/net/pcal/quicksort/mixins/QuicksortChestMixin.java
@@ -4,23 +4,32 @@ import net.minecraft.world.entity.ContainerUser;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import net.pcal.quicksort.QuicksortService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static net.pcal.quicksort.QuicksortService.LOGGER_NAME;
+import static net.pcal.quicksort.QuicksortService.LOG_PREFIX;
+
 @Mixin(ChestBlockEntity.class)
 public class QuicksortChestMixin {
+
+    private static final Logger LOG = LogManager.getLogger(LOGGER_NAME);
 
     @Inject(method = "stopOpen", at = @At("TAIL"))
     public void stopOpen(ContainerUser user, CallbackInfo ci) {
         ChestBlockEntity e = (ChestBlockEntity) (Object) this;
+        LOG.debug(LOG_PREFIX + "Mixin: Chest stopOpen called at " + e.getBlockPos());
         QuicksortService.getInstance().onChestClosed(e);
     }
 
     @Inject(method = "startOpen", at = @At("TAIL"))
     public void startOpen(ContainerUser user, CallbackInfo ci) {
         ChestBlockEntity e = (ChestBlockEntity) (Object) this;
+        LOG.debug(LOG_PREFIX + "Mixin: Chest startOpen called at " + e.getBlockPos());
         QuicksortService.getInstance().onChestOpened(e);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,16 +16,23 @@
   "entrypoints": {
     "main": [
       "net.pcal.quicksort.QuicksortInitializer"
+    ],
+    "modmenu": [
+      "net.pcal.quicksort.QuicksortModMenuIntegration"
     ]
   },
   "mixins": [
     "quicksort.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.11",
-    "fabric": "*",
-    "minecraft": ">=1.21",
-    "java": ">=21"
+    "fabricloader": ">=0.19.2",
+    "fabric-api": "*",
+    "cloth-config": ">=26.1.154",
+    "minecraft": ">=26.1-",
+    "java": ">=25"
+  },
+  "suggests": {
+    "modmenu": ">=18.0.0-alpha.8"
   },
   "conflicts": {}
 }

--- a/src/main/resources/quicksort-default-config.json5
+++ b/src/main/resources/quicksort-default-config.json5
@@ -6,50 +6,104 @@
 //
 
 {
-  // List of configurations for quicksort chest types.  A type is determined by the type of the block underneath
+  // List of configurations for quicksort chest types. A type is determined by the type of the block underneath
   // the chest (baseBlockId).
   //
   // If more than one quicksortChest is defined, each will take default values from the one that preceded it.
   //
   'quicksortChests' : [
     {
-      // type of the block under the chest
-      'baseBlockId': 'minecraft:diamond_block',
+      // Type of the block under the chest.
+      'baseBlockId': 'minecraft:iron_block',
 
-      // range at which target chests will be detected
-      'range': 10,
+      // Cube radius where target containers will be detected.
+      'range': 5,
 
-      // number of ticks between items
+      // Number of ticks between transfer attempts.
       'cooldownTicks': 3,
 
-      // number of ticks it takes the item animation to complete.  set to -1 to disable animation.
+      // Number of ticks it takes the item animation to complete. Set to -1 to disable animation.
       'animationTicks': 10,
 
-      // volume of sound
+      // Animation renderer.
+      // - PARTICLE is the default and safest mode.
+      // - ENTITY uses temporary item entities for the old flying-item style.
+      'animationMode': 'PARTICLE',
+
+      // Volume of the transfer sound.
       'soundVolume': 0.75,
 
-      // pitch of sound
+      // Pitch of the transfer sound.
       'soundPitch': 2.0,
 
-      // Sorted items with these ids will only match if their enchantments also match.  This is probably desirable
-      // if you're sorting books and potions books (where you may want to sort by enchantment) but maybe less so if
-      // you're sorting diamond swords (where you probably want to just dump them all in one chest regardless of
+      // If true, solid blocks between the quicksorter and target container will block transfers to that target.
+      'checkObstructions': true,
+
+      // Transfer mode:
+      // - ITEMS sends up to transferAmount items for each item type on each transfer cycle.
+      // - STACKS sends up to transferAmount stacks total on each transfer cycle.
+      'transferMode': 'ITEMS',
+
+      // Amount used by transferMode each time cooldownTicks elapses.
+      // In ITEMS mode this is per item type; in STACKS mode this is total stacks.
+      'transferAmount': 1,
+
+      // If true, sorting starts automatically when the base block receives a redstone signal.
+      // Sorting starts only when the signal changes from off to on, not every tick while powered.
+      'enableRedstoneActivation': false,
+
+      // If true, sorting continues while the quicksort chest is open. If false, opening the chest pauses sorting
+      // and closing it starts sorting again.
+      'continueWhileOpen': false,
+
+      // Sorted items with these ids will only match if their enchantments/components also match. This is probably
+      // desirable if you're sorting books and potions (where you may want to sort by enchantment/effect) but maybe
+      // less so if you're sorting diamond swords (where you probably want to dump them all together regardless of
       // enchantment).
       'enchantmentMatchingIds': ['minecraft:enchanted_book', 'minecraft:potion'],
 
-      // Ids of blocks that will be considered valid targets for sorting.  Listed blocks must be block entities
+      // Ids of blocks that will be considered valid targets for sorting. Listed blocks must be block entities
       // with an inventory.
       'targetContainerIds': ['minecraft:chest']
     },
     {
-      // type of the block under the chest
+      // Type of the block under the chest.
+      'baseBlockId': 'minecraft:copper_block',
+
+      // Cube radius where target containers will be detected.
+      'range': 5
+    },
+    {
+      // Type of the block under the chest.
+      'baseBlockId': 'minecraft:gold_block',
+
+      // Cube radius where target containers will be detected.
+      'range': 10
+    },
+    {
+      // Type of the block under the chest.
       'baseBlockId': 'minecraft:emerald_block',
 
-      // range at which target chests will be detected
-      'range': 5
-    }
+      // Cube radius where target containers will be detected.
+      'range': 25
+    },
+    {
+      // Type of the block under the chest.
+      'baseBlockId': 'minecraft:diamond_block',
 
+      // Cube radius where target containers will be detected.
+      'range': 50
+    },
+    {
+      // Type of the block under the chest.
+      'baseBlockId': 'minecraft:netherite_block',
+
+      // Cube radius where target containers will be detected.
+      'range': 100
+    }
   ],
 
-  'logLevel' : 'INFO'
+  // Log level: DEBUG for detailed diagnostic logs, INFO for normal operation
+  // DEBUG is recommended when troubleshooting world loading issues
+  'logLevel' : 'DEBUG'
 }

--- a/src/main/resources/quicksort.mixins.json
+++ b/src/main/resources/quicksort.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "net.pcal.quicksort.mixins",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "QuicksortChestMixin"
   ],


### PR DESCRIPTION
## Release

- Mod: `Quicksort`
- Loader: `Fabric`
- Minecraft: `26.1`
- Version: `0.22.0+26.1`
- Java: `25`

## Dependencies

- Updated Fabric Loader target to `0.19.2`.
- Updated Fabric API target for Minecraft `26.1`.
- Added Cloth Config API `26.1.154`.
- Added Mod Menu `18.0.0-alpha.8` integration.

## Configuration

- Added Cloth Config screen through Mod Menu.
- Added configurable quicksort chest entries for:
  - `minecraft:iron_block` with radius `5`.
  - `minecraft:copper_block` with radius `5`.
  - `minecraft:gold_block` with radius `10`.
  - `minecraft:emerald_block` with radius `25`.
  - `minecraft:diamond_block` with radius `50`.
  - `minecraft:netherite_block` with radius `100`.
- Added fallback/migration behavior so older configs inherit missing values from defaults.
- Changed `logLevel` in Mod Menu to a selector to avoid crashes from blank text input.

## Sorting Behavior

- Added obstruction checking with `checkObstructions`.
- Rechecks obstruction during transfer attempts, not only when a job is created.
- Added `transferMode`:
  - `ITEMS`: transfers up to `transferAmount` items per item type each cooldown cycle.
  - `STACKS`: transfers up to `transferAmount` stacks total each cooldown cycle.
- Added `transferAmount`.
- Added `continueWhileOpen`.
- Jobs with `continueWhileOpen=true` can keep processing while the source chest GUI is open.
- Jobs now re-check source slots during processing, so newly added items can be picked up while the job is still active.

## Redstone

- Added `enableRedstoneActivation`.
- Redstone activation starts on a rising edge after the world is loaded.
- If redstone remains powered and no job is active, the mod can retry after a short delay instead of requiring manual chest interaction.
- The mod avoids starting duplicate jobs for the same quicksort chest.

## Animation And Sound

- Fixed transfer sound playback by decoupling it from visual animation.
- Added `animationMode`:
  - `PARTICLE` is the default and safest mode.
  - `ENTITY` keeps the old flying-item style with temporary non-saving item entities.
- Entity animation ghosts are tracked and discarded when jobs stop or runtime state resets.

## Stability Notes

- Automatic resume on world load is disabled.
- Reason: starting sorting jobs while the world is still loading can block integrated server spawn loading and leave the game stuck at `Preparing spawn area: 16%`.
- This means an unfinished sorting process is not automatically resumed just because the save was opened again.
- After entering the world, sorting starts through normal triggers:
  - close the source chest, or
  - toggle redstone from off to on when `enableRedstoneActivation=true`.
- A redstone source that is already powered while the world loads is recorded as the initial state and does not start sorting until it changes off and back on.
