### PR TITLE
Updated to 26.1 ONLY

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.14-SNAPSHOT'
+	id 'net.fabricmc.fabric-loom' version "${loom_version}"
 	id "com.modrinth.minotaur" version "2.+"
 	id 'net.darkhax.curseforgegradle' version '1.1.25'
 }
@@ -25,9 +25,8 @@ configurations {
 dependencies {
 	// Fabric & Minecraft
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings loom.officialMojangMappings()
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// JUnit
 	testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
@@ -52,8 +51,8 @@ sourceSets.test {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
-	it.options.release = 17
+	// Minecraft 26.1 development requires Java 25.
+	it.options.release = 25
 }
 
 java {
@@ -61,6 +60,9 @@ java {
 	// if it is present.
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {
@@ -76,7 +78,7 @@ modrinth {
 	projectId = "${project.modrinth_projectId}"
 	versionNumber = project.mod_version
 	versionType = "Release"
-	uploadFile = remapJar
+	uploadFile = jar
 	changelog = "<p><a href='${project.github_projectUrl}/releases/tag/${project.mod_version}'>${project.github_projectUrl}/releases/tag/${project.mod_version}</a></p>"
 	gameVersions = ["${project.minecraft_version}"]
 	loaders = ["fabric"]
@@ -93,7 +95,7 @@ tasks.register('publishCurseForge', TaskPublishCurseForge) {
 
 	// Configure the main artifact
 	// The plugin automatically detects Fabric & Java version from your Loom setup
-	def mainFile = upload(project.curseforge_projectId, remapJar)
+	def mainFile = upload(project.curseforge_projectId, jar)
 
 	mainFile.releaseType = "release"
 	mainFile.changelog = "${project.github_projectUrl}/releases/tag/${project.mod_version}"
@@ -102,8 +104,8 @@ tasks.register('publishCurseForge', TaskPublishCurseForge) {
 	mainFile.addGameVersion(project.minecraft_version)
 	mainFile.addModLoader("Fabric")
 
-	// Ensure remapJar is finished before this runs
-	dependsOn(remapJar)
+	// Ensure jar is finished before this runs
+	dependsOn(jar)
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,14 +9,15 @@ curseforge_projectId = 641431
 
 
 # Quicksort mod
-mod_version = 0.21.1+1.21.11-prerelease
+mod_version = 0.22.0+26.1
 maven_group = net.pcal
 archives_base_name = quicksort
 
 # Fabric & Minecraft
 # https://fabricmc.net/develop
-minecraft_version=1.21.11
-loader_version=0.18.4
-fabric_version=0.141.1+1.21.11
+minecraft_version=26.1
+loader_version=0.19.2
+loom_version=1.16-SNAPSHOT
+fabric_version=0.145.1+26.1
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/pcal/quicksort/QuicksortInitializer.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortInitializer.java
@@ -75,7 +75,7 @@ public class QuicksortInitializer implements ModInitializer {
             logger.info(LOG_PREFIX + "LogLevel set to " + config.logLevel());
         }
         QuicksortService.getInstance().init(config, logger);
-        ServerTickEvents.END_WORLD_TICK.register(QuicksortService.getInstance());
+        ServerTickEvents.END_LEVEL_TICK.register(QuicksortService.getInstance());
         logger.info(LOG_PREFIX + "Initialized");
     }
 }

--- a/src/main/java/net/pcal/quicksort/QuicksortService.java
+++ b/src/main/java/net/pcal/quicksort/QuicksortService.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 import java.util.Random;
 
-import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import org.apache.logging.log4j.Logger;
@@ -44,7 +43,7 @@ import net.pcal.quicksort.QuicksortConfig.QuicksortChestConfig;
 /**
  * Singleton that makes the quicksorter chests do their thing.
  */
-public class QuicksortService implements ServerTickEvents.EndWorldTick {
+public class QuicksortService implements ServerTickEvents.EndLevelTick {
 
     // ===================================================================================
     // Singleton
@@ -110,7 +109,7 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
     }
 
     // ===================================================================================
-    // EndWorldTick implementation
+    // EndLevelTick implementation
 
     @Override
     public void onEndTick(ServerLevel world) {
@@ -209,14 +208,7 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
         }
 
         private void createGhost(ServerLevel world, Item item, TargetContainer targetChest) {
-            world.playSound(
-                    null,                            // Player - if non-null, will play sound for every nearby player *except* the specified player
-                    this.quicksorterPos,             // The position of where the sound will come from
-                    SoundEvents.UI_TOAST_OUT,        // The sound that will play, in this case, the sound the anvil plays when it lands.
-                    SoundSource.BLOCKS,            // This determines which of the volume sliders affect this sound
-                    quicksorterConfig.soundVolume(), // .75f
-                    quicksorterConfig.soundPitch()   // 2.0f // Pitch multiplier, 1 is normal, 0.5 is half pitch, etc
-            );
+            playTransferSound(world, targetChest);
             ItemStack ghostStack = new ItemStack(item, 1);
             GhostItemEntity itemEntity = new GhostItemEntity(world,
                     targetChest.originItemPos.x(), targetChest.originItemPos.y(), targetChest.originItemPos.z(), ghostStack);
@@ -226,6 +218,22 @@ public class QuicksortService implements ServerTickEvents.EndWorldTick {
             itemEntity.setInvulnerable(true);
             itemEntity.setDeltaMovement(targetChest.itemVelocity);
             world.addFreshEntity(itemEntity);
+        }
+
+        private void playTransferSound(ServerLevel world, TargetContainer targetChest) {
+            final float volume = this.quicksorterConfig.soundVolume();
+            if (volume <= 0.0F) return;
+            final Vec3 soundPos = Vec3.atCenterOf(this.quicksorterPos);
+            world.playSeededSound(
+                    null,
+                    soundPos.x(),
+                    soundPos.y(),
+                    soundPos.z(),
+                    SoundEvents.UI_TOAST_OUT,
+                    SoundSource.BLOCKS,
+                    volume,
+                    this.quicksorterConfig.soundPitch(),
+                    world.getRandom().nextLong());
         }
 
         public void stop() {

--- a/src/main/java/net/pcal/quicksort/mixins/QuicksortChestMixin.java
+++ b/src/main/java/net/pcal/quicksort/mixins/QuicksortChestMixin.java
@@ -1,7 +1,6 @@
 package net.pcal.quicksort.mixins;
 
 import net.minecraft.world.entity.ContainerUser;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import net.pcal.quicksort.QuicksortService;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,10 +22,10 @@
     "quicksort.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.11",
-    "fabric": "*",
-    "minecraft": ">=1.21",
-    "java": ">=21"
+    "fabricloader": ">=0.19.2",
+    "fabric-api": "*",
+    "minecraft": ">=26.1-",
+    "java": ">=25"
   },
   "conflicts": {}
 }

--- a/src/main/resources/quicksort.mixins.json
+++ b/src/main/resources/quicksort.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "net.pcal.quicksort.mixins",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
     "QuicksortChestMixin"
   ],


### PR DESCRIPTION
# Changelog

## Minecraft 26.1 Update

### Version And Build

- Updated the mod version to `0.22.0+26.1`.
- Updated the target Minecraft version to `26.1.X`.
- Updated Fabric Loader to `0.19.2`.
- Updated Fabric API to `0.145.1+26.1`.
- Updated Fabric Loom to `1.16-SNAPSHOT`.
- Updated the Gradle Wrapper to `9.4.0`.
- Updated the Java build target to Java `25`.
- Updated the Mixin compatibility level to `JAVA_25`.
- Updated mod metadata to require Minecraft `>=26.1-` and Java `>=25`.

### Gradle Changes

- Switched the Loom plugin id to `net.fabricmc.fabric-loom`.
- Removed the explicit `loom.officialMojangMappings()` dependency because the 26.1 setup failed with `Cannot use Mojang mappings in a non-obfuscated environment`.
- Switched Fabric dependencies from `modImplementation` to `implementation` to match the working 26.1 build setup.
- Updated publishing tasks to use `jar` instead of `remapJar`.

### Fabric API Compatibility

- Updated the server tick event registration from `END_WORLD_TICK` to `END_LEVEL_TICK`.
- Updated the service callback interface from `ServerTickEvents.EndWorldTick` to `ServerTickEvents.EndLevelTick`.
- Updated the related source comment to match the new tick event name.

### Sound Fix

- Fixed transfer sound playback for Minecraft 26.1.
- Kept the original sound identity:
  - `SoundEvents.UI_TOAST_OUT`
  - `SoundSource.BLOCKS`
  - sound position at the quicksort chest
  - configured `soundVolume`
  - configured `soundPitch`
- Replaced the old `playSound` call with `playSeededSound`, which reliably sends the sound from the server to clients in the 26.1 environment.

### Preserved Scope

- No new configuration screen was added.
- No Cloth Config dependency was added.
- No Mod Menu dependency was added.
- No new sorting options were added.
- Existing sorting behavior was kept unchanged except for compatibility fixes required by Minecraft 26.1 and the sound playback fix.

### Verification

- Ran `.\gradlew.bat build`.
- The build completed successfully.
